### PR TITLE
Add fade-out transition when closing game-end dialog

### DIFF
--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -142,9 +142,11 @@ describe('Game', () => {
 
         await user.click(screen.getByRole('button', {name: 'Close'}))
 
-        expect(
-          screen.queryByTestId('game-ends-message'),
-        ).not.toBeInTheDocument()
+        await waitFor(() =>
+          expect(
+            screen.queryByTestId('game-ends-message'),
+          ).not.toBeInTheDocument(),
+        )
       })
 
       it('calls onReturnToWelcome when the Return to Welcome Page button is clicked', async () => {

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -165,14 +165,18 @@ export function Game({
           <div
             className={clsx(
               'fixed inset-0 z-50 bg-black',
-              dialogClosing ? 'animate-backdrop-fade-out' : 'animate-backdrop-fade-in',
+              dialogClosing
+                ? 'animate-backdrop-fade-out'
+                : 'animate-backdrop-fade-in',
             )}
           ></div>
           <div
             className={clsx(
               'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
               'rounded-lg bg-white p-6 shadow-lg',
-              dialogClosing ? 'animate-dialog-fade-out' : 'animate-dialog-fade-in',
+              dialogClosing
+                ? 'animate-dialog-fade-out'
+                : 'animate-dialog-fade-in',
             )}
           >
             <p

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -58,6 +58,7 @@ export function Game({
 }: GameProps) {
   const [boardModel, setBoardModel] = useState<BoardModel>(initialBoardModel)
   const [showGameEndDialog, setShowGameEndDialog] = useState(false)
+  const [dialogClosing, setDialogClosing] = useState(false)
   const [winMessage, setWinMessage] = useState<string | null>(null)
   const [isAIThinking, setIsAIThinking] = useState(false)
   const [lastMoveField, setLastMoveField] = useState<Field | null>(null)
@@ -161,11 +162,18 @@ export function Game({
 
       {showGameEndDialog && (
         <>
-          <div className="fixed inset-0 z-50 bg-black opacity-50"></div>
+          <div
+            className={clsx(
+              'fixed inset-0 z-50 bg-black transition-opacity duration-500',
+              dialogClosing ? 'opacity-0' : 'opacity-50',
+            )}
+          ></div>
           <div
             className={clsx(
               'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
               'rounded-lg bg-white p-6 shadow-lg',
+              'transition-opacity duration-500',
+              dialogClosing ? 'opacity-0' : 'opacity-100',
             )}
           >
             <p
@@ -184,7 +192,11 @@ export function Game({
                 } else if (isDrawStatus(status)) {
                   setWinMessage("It's a draw!")
                 }
-                setShowGameEndDialog(false)
+                setDialogClosing(true)
+                setTimeout(() => {
+                  setShowGameEndDialog(false)
+                  setDialogClosing(false)
+                }, 500)
               }}
             >
               Close

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -165,14 +165,14 @@ export function Game({
           <div
             className={clsx(
               'fixed inset-0 z-50 bg-black',
-              dialogClosing ? 'animate-backdrop-fade-out' : 'opacity-50',
+              dialogClosing ? 'animate-backdrop-fade-out' : 'animate-backdrop-fade-in',
             )}
           ></div>
           <div
             className={clsx(
               'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
               'rounded-lg bg-white p-6 shadow-lg',
-              dialogClosing ? 'animate-dialog-fade-out' : 'opacity-100',
+              dialogClosing ? 'animate-dialog-fade-out' : 'animate-dialog-fade-in',
             )}
           >
             <p

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -164,16 +164,15 @@ export function Game({
         <>
           <div
             className={clsx(
-              'fixed inset-0 z-50 bg-black transition-opacity duration-500',
-              dialogClosing ? 'opacity-0' : 'opacity-50',
+              'fixed inset-0 z-50 bg-black',
+              dialogClosing ? 'animate-backdrop-fade-out' : 'opacity-50',
             )}
           ></div>
           <div
             className={clsx(
               'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
               'rounded-lg bg-white p-6 shadow-lg',
-              'transition-opacity duration-500',
-              dialogClosing ? 'opacity-0' : 'opacity-100',
+              dialogClosing ? 'animate-dialog-fade-out' : 'opacity-100',
             )}
           >
             <p

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,9 +9,17 @@ export default {
           '60%': {transform: 'scale(1.08)'},
           '100%': {transform: 'scale(1)'},
         },
+        'dialog-fade-in': {
+          'from': {opacity: '0'},
+          'to': {opacity: '1'},
+        },
         'dialog-fade-out': {
           'from': {opacity: '1'},
           'to': {opacity: '0'},
+        },
+        'backdrop-fade-in': {
+          'from': {opacity: '0'},
+          'to': {opacity: '0.5'},
         },
         'backdrop-fade-out': {
           'from': {opacity: '0.5'},
@@ -20,7 +28,9 @@ export default {
       },
       animation: {
         'win-pop': 'win-pop 0.6s ease-out',
+        'dialog-fade-in': 'dialog-fade-in 500ms ease-in-out forwards',
         'dialog-fade-out': 'dialog-fade-out 500ms ease-in-out forwards',
+        'backdrop-fade-in': 'backdrop-fade-in 500ms ease-in-out forwards',
         'backdrop-fade-out': 'backdrop-fade-out 500ms ease-in-out forwards',
       },
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,20 +10,20 @@ export default {
           '100%': {transform: 'scale(1)'},
         },
         'dialog-fade-in': {
-          'from': {opacity: '0'},
-          'to': {opacity: '1'},
+          from: {opacity: '0'},
+          to: {opacity: '1'},
         },
         'dialog-fade-out': {
-          'from': {opacity: '1'},
-          'to': {opacity: '0'},
+          from: {opacity: '1'},
+          to: {opacity: '0'},
         },
         'backdrop-fade-in': {
-          'from': {opacity: '0'},
-          'to': {opacity: '0.5'},
+          from: {opacity: '0'},
+          to: {opacity: '0.5'},
         },
         'backdrop-fade-out': {
-          'from': {opacity: '0.5'},
-          'to': {opacity: '0'},
+          from: {opacity: '0.5'},
+          to: {opacity: '0'},
         },
       },
       animation: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,9 +9,19 @@ export default {
           '60%': {transform: 'scale(1.08)'},
           '100%': {transform: 'scale(1)'},
         },
+        'dialog-fade-out': {
+          'from': {opacity: '1'},
+          'to': {opacity: '0'},
+        },
+        'backdrop-fade-out': {
+          'from': {opacity: '0.5'},
+          'to': {opacity: '0'},
+        },
       },
       animation: {
         'win-pop': 'win-pop 0.6s ease-out',
+        'dialog-fade-out': 'dialog-fade-out 500ms ease-in-out forwards',
+        'backdrop-fade-out': 'backdrop-fade-out 500ms ease-in-out forwards',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Add a 500ms fade-out transition to the game-end dialog backdrop and content
- Track a separate `dialogClosing` state to apply `opacity-0` during the transition
- Defer DOM removal until the fade-out animation completes via `setTimeout`
- Update unit test to use `waitFor` to account for the animation delay

Closes #43