### PR TITLE
Reduce Start New Game button animation from scale-150 to scale-110

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function WelcomePage({
       <div
         className={clsx('my-3 flex justify-center', {
           'transition-transform duration-200 ease-in-out': true,
-          'scale-150 transform': showGame === 0,
+          'scale-110 transform': showGame === 0,
         })}
       >
         <Button


### PR DESCRIPTION
## Summary

- Reduces the "Start New Game" button scale animation from `scale-150` to `scale-110` in `src/App.tsx`, fixing the oversized button animation reported in #46.
- The button still provides satisfying press feedback without appearing disproportionately large.

Closes #46