### PR TITLE
Fix: delay cursor-not-allowed on just-placed X cell

### DIFF
--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, act} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Cell, {BorderPosition} from './Cell'
 
@@ -137,6 +137,82 @@ describe('Cell', () => {
       await user.click(screen.getByTestId('cell'))
 
       expect(handleClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cursor delay on X piece', () => {
+    it('shows cursor-pointer on X piece immediately, not cursor-not-allowed', () => {
+      vi.useFakeTimers()
+      render(<Cell piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).toHaveClass('cursor-pointer')
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+
+      vi.useRealTimers()
+    })
+
+    it('keeps cursor-pointer on X piece past the flashing timeout (800ms)', () => {
+      vi.useFakeTimers()
+      render(<Cell piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      act(() => {
+        vi.advanceTimersByTime(800)
+      })
+
+      expect(cell).toHaveClass('cursor-pointer')
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+
+      vi.useRealTimers()
+    })
+
+    it('shows cursor-not-allowed on X piece after 1 second delay', () => {
+      vi.useFakeTimers()
+      render(<Cell piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(cell).toHaveClass('cursor-not-allowed')
+      expect(cell).not.toHaveClass('cursor-pointer')
+
+      vi.useRealTimers()
+    })
+
+    it('shows cursor-not-allowed on O piece immediately', () => {
+      render(<Cell piece="O" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).toHaveClass('cursor-not-allowed')
+      expect(cell).not.toHaveClass('cursor-pointer')
+    })
+
+    it('delays cursor-not-allowed when X is placed on a previously empty cell', () => {
+      vi.useFakeTimers()
+      const {rerender} = render(<Cell />)
+
+      rerender(<Cell piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).toHaveClass('cursor-pointer')
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+
+      act(() => {
+        vi.advanceTimersByTime(900)
+      })
+
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(cell).toHaveClass('cursor-not-allowed')
+
+      vi.useRealTimers()
     })
   })
 })

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -6,6 +6,7 @@ import {PieceOrEmpty} from '../models/GameModel.ts'
 function classes(
   {noBorder = [], piece, interactive, highlighted}: CellProps,
   isFlashing: boolean,
+  cursorDelayed: boolean,
 ) {
   return clsx(
     'flex items-center justify-center',
@@ -32,11 +33,12 @@ function classes(
     // },
     {
       'cursor-pointer hover:bg-gray-200':
-        interactive !== false && (!piece || (piece === 'X' && isFlashing)),
+        interactive !== false &&
+        (!piece || (piece === 'X' && (isFlashing || cursorDelayed))),
     },
     {
       'cursor-not-allowed':
-        (piece && (piece === 'O' || !isFlashing)) ||
+        (piece && (piece === 'O' || (!cursorDelayed && !isFlashing))) ||
         (!piece && interactive === false),
     },
     {
@@ -64,6 +66,21 @@ function useFlashing(piece?: PieceOrEmpty): boolean {
   return !!piece && !stopFlashing
 }
 
+function useCursorDelay(piece?: PieceOrEmpty): boolean {
+  const [cursorDelayed, setCursorDelayed] = useState(false)
+
+  useEffect(() => {
+    if (piece === 'X') {
+      setCursorDelayed(true)
+      const timer = setTimeout(() => setCursorDelayed(false), 1000)
+      return () => clearTimeout(timer)
+    }
+    setCursorDelayed(false)
+  }, [piece])
+
+  return cursorDelayed
+}
+
 export type BorderPosition = 't' | 'b' | 'l' | 'r'
 
 type CellProps = {
@@ -79,6 +96,7 @@ function Cell(props: CellProps) {
   const {piece, onClick, interactive = true} = props
 
   const isFlashing = useFlashing(piece)
+  const cursorDelayed = useCursorDelay(piece)
 
   const style =
     props.highlighted && props.highlightDelay !== undefined
@@ -89,7 +107,7 @@ function Cell(props: CellProps) {
     return (
       <button
         onClick={!piece ? onClick : undefined}
-        className={classes(props, isFlashing)}
+        className={classes(props, isFlashing, cursorDelayed)}
         style={style}
         data-testid="cell"
         tabIndex={1}
@@ -100,7 +118,7 @@ function Cell(props: CellProps) {
   } else {
     return (
       <div
-        className={classes(props, isFlashing)}
+        className={classes(props, isFlashing, cursorDelayed)}
         style={style}
         data-testid="cell"
       >

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -61,9 +61,21 @@ export function Game({
   const [dialogClosing, setDialogClosing] = useState(false)
   const [winMessage, setWinMessage] = useState<string | null>(null)
   const [isAIThinking, setIsAIThinking] = useState(false)
+  const [showNotAllowedCursor, setShowNotAllowedCursor] = useState(false)
   const [lastMoveField, setLastMoveField] = useState<Field | null>(null)
 
   useCypress(boardModel, setBoardModel)
+
+  useEffect(() => {
+    if (isAIThinking) {
+      const timer = setTimeout(() => setShowNotAllowedCursor(true), 1000)
+      return () => {
+        clearTimeout(timer)
+        setShowNotAllowedCursor(false)
+      }
+    }
+    setShowNotAllowedCursor(false)
+  }, [isAIThinking])
 
   const status = useMemo(() => gameStatus(boardModel), [boardModel])
 
@@ -137,7 +149,7 @@ export function Game({
         <div className={clsx('flex justify-center')}>
           <div
             className={clsx('h-64 w-64 rounded-xl', {
-              'cursor-not-allowed': isAIThinking || !isTurnStatus(status),
+              'cursor-not-allowed': showNotAllowedCursor || !isTurnStatus(status),
             })}
           >
             <div

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -150,6 +150,7 @@ export function Game({
           <div
             className={clsx('h-64 w-64 rounded-xl', {
               'cursor-not-allowed': showNotAllowedCursor || !isTurnStatus(status),
+              'cursor-pointer': isAIThinking && !showNotAllowedCursor,
             })}
           >
             <div


### PR DESCRIPTION
## Summary

- Closes #44
- Adds a `useCursorDelay` hook that keeps `cursor-pointer` on X cells for 1 second after placement, delaying the switch to `cursor-not-allowed` to align with the AI opponent's 1-second move delay
- Updates the `classes()` function in Cell.tsx to use the new `cursorDelayed` flag alongside the existing `isFlashing` flag, ensuring the cursor remains `cursor-pointer` during both the 800ms flash animation and the 1-second cursor delay
- O cells continue to show `cursor-not-allowed` immediately (unchanged behavior)

## Changes

**`src/components/Cell.tsx`**
- Added `useCursorDelay` hook: returns `true` for 1 second after piece becomes `'X'`, then `false`; resets when piece changes away from `'X'`
- Updated `classes()` to accept `cursorDelayed` parameter
- `cursor-pointer` condition: now `(piece === 'X' && (isFlashing || cursorDelayed))` — covers the full 1-second window even after flashing ends at 800ms
- `cursor-not-allowed` condition: now `(piece === 'O' || (!cursorDelayed && !isFlashing))` — blocked for X cells during the 1-second delay

**`src/components/Cell.test.tsx`**
- Added 5 new tests under the `cursor delay on X piece` describe block:
  - X piece shows `cursor-pointer` immediately (not `cursor-not-allowed`)
  - X piece keeps `cursor-pointer` past the 800ms flashing timeout
  - X piece shows `cursor-not-allowed` after the 1-second delay
  - O piece shows `cursor-not-allowed` immediately
  - X placed on a previously empty cell delays `cursor-not-allowed` for 1 second