### PR TITLE
Design overhaul: Classic Wooden Board theme with warm colors, responsive mobile layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,9 @@ function WelcomePage({
 }) {
   return (
     <>
-      <h1 className={clsx('py-6 text-center')}>Welcome to React Tic Tac Toe</h1>
+      <h1 className="py-6 text-center text-3xl font-bold text-bark">
+        Welcome to React Tic Tac Toe
+      </h1>
       <div
         className={clsx('my-3 flex justify-center', {
           'transition-transform duration-200 ease-in-out': true,
@@ -33,15 +35,17 @@ function WelcomePage({
           Start New Game
         </Button>
       </div>
-      <h2 className={clsx('py-6 text-center')}>Past Games</h2>
-      <div className={clsx('flex flex-wrap justify-around gap-6')}>
-        <div className="h-28 w-28 flex-col rounded-xl border-2 border-slate-200 p-2 shadow hover:border-slate-400">
+      <h2 className="py-6 text-center text-xl font-semibold text-bark">
+        Past Games
+      </h2>
+      <div className="flex flex-wrap justify-around gap-6">
+        <div className="h-28 w-28 flex-col rounded-xl border-2 border-wood/30 bg-cream/50 p-2 shadow-md hover:border-wood/50">
           <Board interactive={false} />
         </div>
-        <div className="h-28 w-28 flex-col rounded-xl border-2 border-slate-200 p-2 shadow hover:border-slate-400">
+        <div className="h-28 w-28 flex-col rounded-xl border-2 border-wood/30 bg-cream/50 p-2 shadow-md hover:border-wood/50">
           <Board interactive={false} />
         </div>
-        <div className="h-28 w-28 flex-col rounded-xl border-2 border-slate-200 p-2 shadow hover:border-slate-400">
+        <div className="h-28 w-28 flex-col rounded-xl border-2 border-wood/30 bg-cream/50 p-2 shadow-md hover:border-wood/50">
           <Board interactive={false} />
         </div>
       </div>
@@ -53,9 +57,11 @@ function App() {
   const [showGame, setShowGame] = useState<ShowGameStatus>(false)
 
   return (
-    <div className="container mx-auto">
+    <div className="min-h-screen">
       {!showGame && (
-        <WelcomePage showGame={showGame} setShowGame={setShowGame} />
+        <div className="flex min-h-screen flex-col items-center justify-center px-4">
+          <WelcomePage showGame={showGame} setShowGame={setShowGame} />
+        </div>
       )}
       <div
         className={clsx('transition-opacity duration-500 ease-in-out', {

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -91,10 +91,10 @@ describe('Board', () => {
       render(<Board boardModel={boardModel} winningFields={[0, 1, 2]} />)
 
       const cells = screen.getAllByTestId('cell')
-      expect(cells[0]).toHaveClass('bg-yellow-300')
-      expect(cells[1]).toHaveClass('bg-yellow-300')
-      expect(cells[2]).toHaveClass('bg-yellow-300')
-      expect(cells[3]).not.toHaveClass('bg-yellow-300')
+      expect(cells[0]).toHaveClass('bg-flame')
+      expect(cells[1]).toHaveClass('bg-flame')
+      expect(cells[2]).toHaveClass('bg-flame')
+      expect(cells[3]).not.toHaveClass('bg-flame')
     })
 
     it('does not highlight any cells when winningFields is not provided', () => {
@@ -104,7 +104,7 @@ describe('Board', () => {
 
       const cells = screen.getAllByTestId('cell')
       cells.forEach(cell => {
-        expect(cell).not.toHaveClass('bg-yellow-300')
+        expect(cell).not.toHaveClass('bg-flame')
       })
     })
   })

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -8,7 +8,9 @@ import {
   getFieldContent,
 } from '../models/GameModel.ts'
 
-const classes = clsx('grid aspect-square max-h-full grid-cols-3 grid-rows-3')
+const classes = clsx(
+  'wood-grain grid aspect-square max-h-full grid-cols-3 grid-rows-3 overflow-hidden rounded-lg shadow-lg',
+)
 
 const fieldsNoBorder: BorderPosition[][] = [
   ['l', 't'],

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,10 +4,10 @@ import {ButtonHTMLAttributes} from 'react'
 type ButtonSize = 'normal' | 'large'
 
 const classes = (size: ButtonSize) => {
-  const baseStyles = 'bg-blue-500 text-white'
-  const hoverStyles = 'hover:bg-blue-600'
+  const baseStyles = 'bg-flame text-white font-semibold'
+  const hoverStyles = 'hover:bg-flame-dark'
   const focusStyles =
-    'focus-visible:outline-none focus-visible:ring focus-visible:ring-blue-300'
+    'focus-visible:outline-none focus-visible:ring focus-visible:ring-flame/50'
 
   const stylesForSize = (size: ButtonSize) => {
     if (size === 'normal') {

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -58,12 +58,12 @@ describe('Cell', () => {
   describe('when highlighted', () => {
     it('applies the highlighted background class', () => {
       render(<Cell piece="X" highlighted />)
-      expect(screen.getByTestId('cell')).toHaveClass('bg-yellow-300')
+      expect(screen.getByTestId('cell')).toHaveClass('bg-flame')
     })
 
     it('does not apply the highlighted background class when not highlighted', () => {
       render(<Cell piece="X" />)
-      expect(screen.getByTestId('cell')).not.toHaveClass('bg-yellow-300')
+      expect(screen.getByTestId('cell')).not.toHaveClass('bg-flame')
     })
   })
 

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx'
 import {MouseEventHandler, useEffect, useState} from 'react'
 import {PieceOrEmpty} from '../models/GameModel.ts'
 
-// TODO: we should have an eslint rule to either use function or const
 function classes(
   {noBorder = [], piece, interactive, highlighted}: CellProps,
   isFlashing: boolean,
@@ -10,10 +9,11 @@ function classes(
 ) {
   return clsx(
     'flex items-center justify-center',
-    'text-5xl',
-    'border border-black',
-    'select-none',
-    'focus-visible:outline-none focus-visible:ring focus-visible:ring-inset focus-visible:ring-blue-300',
+    'text-5xl font-bold text-bark',
+    'border border-wood-dark',
+    'select-none bg-cream/50',
+    'min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0',
+    'focus-visible:outline-none focus-visible:ring focus-visible:ring-inset focus-visible:ring-flame/50',
     {
       'border-t-0': noBorder.includes('t'),
       'border-r-0': noBorder.includes('r'),
@@ -22,17 +22,14 @@ function classes(
     },
     {'transition-colors duration-1000': piece === 'X' && !highlighted},
     {
-      'bg-blue-200 ': isFlashing && piece === 'O' && !highlighted,
+      'bg-honey/30': isFlashing && piece === 'O' && !highlighted,
     },
     {
       'transition-colors duration-1000':
         piece === 'O' && !isFlashing && !highlighted,
     },
-    // {
-    //   "hover:text-gray-400 hover:after:content-['X']": true,
-    // },
     {
-      'cursor-pointer hover:bg-gray-200':
+      'cursor-pointer hover:bg-honey/30':
         interactive !== false &&
         (!piece || (piece === 'X' && (isFlashing || cursorDelayed))),
     },
@@ -42,7 +39,7 @@ function classes(
         (!piece && interactive === false),
     },
     {
-      'animate-win-pop bg-yellow-300 transition-colors duration-500':
+      'animate-win-pop bg-flame text-cream transition-colors duration-500':
         highlighted,
     },
   )
@@ -107,7 +104,10 @@ function Cell(props: CellProps) {
     return (
       <button
         onClick={!piece ? onClick : undefined}
-        className={classes(props, isFlashing, cursorDelayed)}
+        className={clsx(
+          classes(props, isFlashing, cursorDelayed),
+          piece && 'piece-shadow',
+        )}
         style={style}
         data-testid="cell"
         tabIndex={1}
@@ -118,7 +118,10 @@ function Cell(props: CellProps) {
   } else {
     return (
       <div
-        className={classes(props, isFlashing, cursorDelayed)}
+        className={clsx(
+          classes(props, isFlashing, cursorDelayed),
+          piece && 'piece-shadow',
+        )}
         style={style}
         data-testid="cell"
       >

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -385,10 +385,10 @@ describe('Game', () => {
       render(<Game initialBoardModel={boardModel} />)
 
       const cells = screen.getAllByTestId('cell')
-      expect(cells[0]).toHaveClass('bg-yellow-300')
-      expect(cells[1]).toHaveClass('bg-yellow-300')
-      expect(cells[2]).toHaveClass('bg-yellow-300')
-      expect(cells[3]).not.toHaveClass('bg-yellow-300')
+      expect(cells[0]).toHaveClass('bg-flame')
+      expect(cells[1]).toHaveClass('bg-flame')
+      expect(cells[2]).toHaveClass('bg-flame')
+      expect(cells[3]).not.toHaveClass('bg-flame')
     })
 
     it('does not highlight winning move cell until dialog opens', async () => {
@@ -403,10 +403,10 @@ describe('Game', () => {
 
       const cells = screen.getAllByTestId('cell')
       // The other two winning cells are highlighted immediately
-      expect(cells[0]).toHaveClass('bg-yellow-300')
-      expect(cells[1]).toHaveClass('bg-yellow-300')
+      expect(cells[0]).toHaveClass('bg-flame')
+      expect(cells[1]).toHaveClass('bg-flame')
       // The winning move cell is NOT highlighted yet
-      expect(cells[2]).not.toHaveClass('bg-yellow-300')
+      expect(cells[2]).not.toHaveClass('bg-flame')
 
       // Once the dialog opens the winning move cell is also highlighted
       await waitFor(
@@ -414,13 +414,13 @@ describe('Game', () => {
           expect(screen.getByTestId('game-ends-message')).toBeInTheDocument(),
         {timeout: 3000},
       )
-      expect(cells[2]).toHaveClass('bg-yellow-300')
+      expect(cells[2]).toHaveClass('bg-flame')
 
       // After closing the dialog all three winning cells remain highlighted
       await user.click(screen.getByRole('button', {name: 'Close'}))
-      expect(cells[0]).toHaveClass('bg-yellow-300')
-      expect(cells[1]).toHaveClass('bg-yellow-300')
-      expect(cells[2]).toHaveClass('bg-yellow-300')
+      expect(cells[0]).toHaveClass('bg-flame')
+      expect(cells[1]).toHaveClass('bg-flame')
+      expect(cells[2]).toHaveClass('bg-flame')
     })
 
     it('does not highlight any cells when game is in progress', () => {
@@ -428,7 +428,7 @@ describe('Game', () => {
 
       const cells = screen.getAllByTestId('cell')
       cells.forEach(cell => {
-        expect(cell).not.toHaveClass('bg-yellow-300')
+        expect(cell).not.toHaveClass('bg-flame')
       })
     })
   })

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -161,7 +161,7 @@ export function Game({
 
         <div className="flex flex-1 items-center justify-center px-4 py-4 sm:flex-initial sm:p-4">
           <div
-            className={clsx('w-full max-w-xs sm:max-w-sm', {
+            className={clsx('w-64 sm:w-80', {
               'cursor-not-allowed':
                 showNotAllowedCursor || !isTurnStatus(status),
               'cursor-pointer': isAIThinking && !showNotAllowedCursor,

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -142,14 +142,28 @@ export function Game({
 
   return (
     <>
-      <div data-testid="game">
-        <h1 className={clsx('py-6 text-center')}>
-          {winMessage ?? 'Have fun with this game!'}
-        </h1>
-        <div className={clsx('flex justify-center')}>
+      <div
+        data-testid="game"
+        className="flex min-h-screen flex-col sm:min-h-0 sm:items-center sm:justify-center sm:py-8"
+      >
+        <div className="flex flex-col items-center px-4 pt-6 sm:pt-0">
+          <h1 className="py-4 text-center text-2xl font-bold text-bark sm:py-6 sm:text-3xl">
+            {winMessage ?? 'Have fun with this game!'}
+          </h1>
+          {winMessage !== null && onReturnToWelcome && (
+            <div className="pb-2">
+              <Button onClick={onReturnToWelcome}>
+                Return to Welcome Page
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-1 items-center justify-center px-4 py-4 sm:flex-initial sm:p-4">
           <div
-            className={clsx('h-64 w-64 rounded-xl', {
-              'cursor-not-allowed': showNotAllowedCursor || !isTurnStatus(status),
+            className={clsx('w-full max-w-xs sm:max-w-sm', {
+              'cursor-not-allowed':
+                showNotAllowedCursor || !isTurnStatus(status),
               'cursor-pointer': isAIThinking && !showNotAllowedCursor,
             })}
           >
@@ -166,18 +180,13 @@ export function Game({
             </div>
           </div>
         </div>
-        {winMessage !== null && onReturnToWelcome && (
-          <div className={clsx('mt-6 flex justify-center')}>
-            <Button onClick={onReturnToWelcome}>Return to Welcome Page</Button>
-          </div>
-        )}
       </div>
 
       {showGameEndDialog && (
         <>
           <div
             className={clsx(
-              'fixed inset-0 z-50 bg-black',
+              'fixed inset-0 z-50 bg-bark/60',
               dialogClosing
                 ? 'animate-backdrop-fade-out'
                 : 'animate-backdrop-fade-in',
@@ -186,14 +195,14 @@ export function Game({
           <div
             className={clsx(
               'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
-              'rounded-lg bg-white p-6 shadow-lg',
+              'rounded-lg border border-wood/30 bg-cream p-6 shadow-xl',
               dialogClosing
                 ? 'animate-dialog-fade-out'
                 : 'animate-dialog-fade-in',
             )}
           >
             <p
-              className="mb-3 text-lg font-semibold text-gray-800"
+              className="mb-3 text-lg font-semibold text-bark"
               data-testid="game-ends-message"
             >
               {isWinStatus(status) && (

--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,25 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-cream text-bark;
+  }
+}
+
+.wood-grain {
+  background-color: #8b5e3c;
+  background-image: repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 2px,
+      rgba(0, 0, 0, 0.03) 2px,
+      rgba(0, 0, 0, 0.03) 4px
+    ),
+    linear-gradient(180deg, #a0522d 0%, #8b5e3c 50%, #7a5232 100%);
+}
+
+.piece-shadow {
+  text-shadow: 1px 2px 3px rgba(0, 0, 0, 0.25);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,23 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      colors: {
+        wood: {
+          DEFAULT: '#8B5E3C',
+          light: '#A0522D',
+          dark: '#5D3A1A',
+        },
+        cream: {
+          DEFAULT: '#FFF8E7',
+          dark: '#F5E6C8',
+        },
+        honey: '#D4A056',
+        flame: {
+          DEFAULT: '#E8751A',
+          dark: '#C86415',
+        },
+        bark: '#3E2723',
+      },
       keyframes: {
         'win-pop': {
           '0%': {transform: 'scale(0.85)'},


### PR DESCRIPTION
## Summary

- **Warm color palette**: Added custom Tailwind theme colors (wood, cream, honey, flame, bark) replacing the cool blue/gray/yellow scheme
- **Wood-grain board**: CSS gradient pattern simulating wood texture with grooved dark border lines between cells
- **Carved piece feel**: X and O pieces use dark brown text with text-shadow for a tactile, raised token appearance
- **Burnt orange highlights**: Winning cells highlighted in flame (#E8751A) instead of yellow
- **Responsive mobile layout**: Top-half game info / bottom-half board on small screens, centered layout on desktop
- **44×44px tap targets**: Minimum cell size on mobile for WCAG accessibility
- **Warm-styled dialogs**: Game-end dialog uses cream background with bark overlay
- **Warm welcome page**: Updated mini boards with wood-toned borders and shadows
- **Warm buttons**: Flame accent color with hover/focus states

Closes #49

## Test plan

- [x] All 168 existing unit/integration tests pass (updated highlight assertions from `bg-yellow-300` to `bg-flame`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint --max-warnings 0`)
- [x] Prettier formatting applied (`npm run prettier`)
- [ ] Visual review on mobile and desktop viewports
- [ ] Cypress E2E tests pass