### PR TITLE
Game end dialog: center the button and improve the overall design

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -28,11 +28,16 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 function Button({
   size = 'normal',
   children,
+  className,
   dataTestid,
   ...props
 }: ButtonProps) {
   return (
-    <button className={classes(size)} data-testid={dataTestid} {...props}>
+    <button
+      className={clsx(classes(size), className)}
+      data-testid={dataTestid}
+      {...props}
+    >
       {children}
     </button>
   )

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -194,38 +194,52 @@ export function Game({
           ></div>
           <div
             className={clsx(
-              'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform',
-              'rounded-lg border border-wood/30 bg-cream p-6 shadow-xl',
+              'fixed left-1/2 top-1/2 z-50 min-w-[280px] -translate-x-1/2 -translate-y-1/2 transform',
+              'overflow-hidden rounded-2xl border border-wood/30 bg-cream shadow-2xl',
               dialogClosing
                 ? 'animate-dialog-fade-out'
-                : 'animate-dialog-fade-in',
+                : 'animate-dialog-scale-in',
             )}
           >
-            <p
-              className="mb-3 text-lg font-semibold text-bark"
-              data-testid="game-ends-message"
-            >
-              {isWinStatus(status) && (
-                <span>The winner is {status.player}!</span>
-              )}
-              {isDrawStatus(status) && <span>It&apos;s a draw!</span>}
-            </p>
-            <Button
-              onClick={() => {
-                if (isWinStatus(status)) {
-                  setWinMessage(`The winner is ${status.player}!`)
-                } else if (isDrawStatus(status)) {
-                  setWinMessage("It's a draw!")
-                }
-                setDialogClosing(true)
-                setTimeout(() => {
-                  setShowGameEndDialog(false)
-                  setDialogClosing(false)
-                }, 500)
-              }}
-            >
-              Close
-            </Button>
+            <div
+              className={clsx('h-2', {
+                'bg-honey': isWinStatus(status),
+                'bg-wood/40': isDrawStatus(status),
+              })}
+            />
+            <div className="px-8 pb-8 pt-6 text-center">
+              <div className="mb-3 text-5xl" aria-hidden="true">
+                {isWinStatus(status) && '🏆'}
+                {isDrawStatus(status) && '🤝'}
+              </div>
+              <p
+                className="mb-6 text-xl font-bold text-bark"
+                data-testid="game-ends-message"
+              >
+                {isWinStatus(status) && (
+                  <span>The winner is {status.player}!</span>
+                )}
+                {isDrawStatus(status) && <span>It&apos;s a draw!</span>}
+              </p>
+              <Button
+                size="large"
+                className="w-full"
+                onClick={() => {
+                  if (isWinStatus(status)) {
+                    setWinMessage(`The winner is ${status.player}!`)
+                  } else if (isDrawStatus(status)) {
+                    setWinMessage("It's a draw!")
+                  }
+                  setDialogClosing(true)
+                  setTimeout(() => {
+                    setShowGameEndDialog(false)
+                    setDialogClosing(false)
+                  }, 500)
+                }}
+              >
+                Close
+              </Button>
+            </div>
           </div>
         </>
       )}

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -219,9 +219,7 @@ export function Game({
                   {isWinStatus(status) && (
                     <span>The winner is {status.player}!</span>
                   )}
-                  {isDrawStatus(status) && (
-                    <span>It&apos;s a draw!</span>
-                  )}
+                  {isDrawStatus(status) && <span>It&apos;s a draw!</span>}
                 </p>
                 <Button
                   size="large"

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -192,53 +192,56 @@ export function Game({
                 : 'animate-backdrop-fade-in',
             )}
           ></div>
-          <div
-            className={clsx(
-              'fixed left-1/2 top-1/2 z-50 min-w-[280px] -translate-x-1/2 -translate-y-1/2 transform',
-              'overflow-hidden rounded-2xl border border-wood/30 bg-cream shadow-2xl',
-              dialogClosing
-                ? 'animate-dialog-fade-out'
-                : 'animate-dialog-scale-in',
-            )}
-          >
+          <div className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform">
             <div
-              className={clsx('h-2', {
-                'bg-honey': isWinStatus(status),
-                'bg-wood/40': isDrawStatus(status),
-              })}
-            />
-            <div className="px-8 pb-8 pt-6 text-center">
-              <div className="mb-3 text-5xl" aria-hidden="true">
-                {isWinStatus(status) && '🏆'}
-                {isDrawStatus(status) && '🤝'}
+              className={clsx(
+                'min-w-[280px] overflow-hidden rounded-2xl border border-wood/30 bg-cream shadow-2xl',
+                dialogClosing
+                  ? 'animate-dialog-fade-out'
+                  : 'animate-dialog-scale-in',
+              )}
+            >
+              <div
+                className={clsx('h-2', {
+                  'bg-honey': isWinStatus(status),
+                  'bg-wood/40': isDrawStatus(status),
+                })}
+              />
+              <div className="px-8 pb-8 pt-6 text-center">
+                <div className="mb-3 text-5xl" aria-hidden="true">
+                  {isWinStatus(status) && '🏆'}
+                  {isDrawStatus(status) && '🤝'}
+                </div>
+                <p
+                  className="mb-6 text-xl font-bold text-bark"
+                  data-testid="game-ends-message"
+                >
+                  {isWinStatus(status) && (
+                    <span>The winner is {status.player}!</span>
+                  )}
+                  {isDrawStatus(status) && (
+                    <span>It&apos;s a draw!</span>
+                  )}
+                </p>
+                <Button
+                  size="large"
+                  className="w-full"
+                  onClick={() => {
+                    if (isWinStatus(status)) {
+                      setWinMessage(`The winner is ${status.player}!`)
+                    } else if (isDrawStatus(status)) {
+                      setWinMessage("It's a draw!")
+                    }
+                    setDialogClosing(true)
+                    setTimeout(() => {
+                      setShowGameEndDialog(false)
+                      setDialogClosing(false)
+                    }, 500)
+                  }}
+                >
+                  Close
+                </Button>
               </div>
-              <p
-                className="mb-6 text-xl font-bold text-bark"
-                data-testid="game-ends-message"
-              >
-                {isWinStatus(status) && (
-                  <span>The winner is {status.player}!</span>
-                )}
-                {isDrawStatus(status) && <span>It&apos;s a draw!</span>}
-              </p>
-              <Button
-                size="large"
-                className="w-full"
-                onClick={() => {
-                  if (isWinStatus(status)) {
-                    setWinMessage(`The winner is ${status.player}!`)
-                  } else if (isDrawStatus(status)) {
-                    setWinMessage("It's a draw!")
-                  }
-                  setDialogClosing(true)
-                  setTimeout(() => {
-                    setShowGameEndDialog(false)
-                    setDialogClosing(false)
-                  }, 500)
-                }}
-              >
-                Close
-              </Button>
             </div>
           </div>
         </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,11 @@ export default {
           from: {opacity: '0'},
           to: {opacity: '1'},
         },
+        'dialog-scale-in': {
+          '0%': {opacity: '0', transform: 'scale(0.85)'},
+          '60%': {opacity: '1', transform: 'scale(1.05)'},
+          '100%': {opacity: '1', transform: 'scale(1)'},
+        },
         'dialog-fade-out': {
           from: {opacity: '1'},
           to: {opacity: '0'},
@@ -46,6 +51,7 @@ export default {
       animation: {
         'win-pop': 'win-pop 0.6s ease-out',
         'dialog-fade-in': 'dialog-fade-in 500ms ease-in-out forwards',
+        'dialog-scale-in': 'dialog-scale-in 500ms ease-out forwards',
         'dialog-fade-out': 'dialog-fade-out 500ms ease-in-out forwards',
         'backdrop-fade-in': 'backdrop-fade-in 500ms ease-in-out forwards',
         'backdrop-fade-out': 'backdrop-fade-out 500ms ease-in-out forwards',


### PR DESCRIPTION
## Summary

- Center the Close button with full-width layout inside a `text-center` container
- Add colored accent bar at top of dialog (gold `bg-honey` for wins, muted `bg-wood/40` for draws)
- Add emoji above message text (🏆 for win, 🤝 for draw) with `aria-hidden`
- Increase text prominence to `text-xl font-bold` with wider padding
- Upgrade dialog container: `rounded-2xl`, `shadow-2xl`, `min-w-[280px]`
- Replace simple fade-in with scale-in animation (bouncy entrance: scale 0.85 → 1.05 → 1)
- Update `Button` component to accept and merge a `className` prop via `clsx`

Closes #51