### PR TITLE
Implement a random AI strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ npm run build
 
 - **TypeScript strict mode** is enabled; avoid `any` and prefer explicit types.
 - **ESLint** is configured with zero warnings allowed (`--max-warnings 0`). Run `npm run lint` before committing.
-- **Prettier** is the formatter; run `npm run prettier` to auto-format.
+- **Prettier** is the formatter; run `npm run prettier` before committing to auto-format.
 - Business logic lives in `src/models/` and must remain free of React imports.
 - UI components live in `src/components/` and should delegate game logic to the models.
 - AI strategies follow the `Strategy` type signature: `(boardModel: BoardModel) => Field`.

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -1,5 +1,5 @@
-import {createInitialBoardModel, placeMoves} from './GameModel.ts'
-import {deterministicStrategy} from './Strategies.ts'
+import {createInitialBoardModel, Field, isEmptyField, placeMoves} from './GameModel.ts'
+import {deterministicStrategy, randomStrategy} from './Strategies.ts'
 
 describe('Strategies', () => {
   describe('deterministicStrategy', () => {
@@ -36,6 +36,55 @@ describe('Strategies', () => {
         [8, 'X'],
       )
       expect(() => deterministicStrategy(boardModel)).toThrow()
+    })
+  })
+
+  describe('randomStrategy', () => {
+    it('returns an empty field on an empty board', () => {
+      const boardModel = createInitialBoardModel()
+      const field = randomStrategy(boardModel)
+      expect(isEmptyField(boardModel, field)).toBe(true)
+    })
+
+    it('returns an empty field on a partially filled board', () => {
+      const boardModel = placeMoves([0, 'X'], [4, 'O'])
+      const field = randomStrategy(boardModel)
+      expect(isEmptyField(boardModel, field)).toBe(true)
+    })
+
+    it('only returns fields that are empty on the given board', () => {
+      const boardModel = placeMoves([0, 'X'], [4, 'O'])
+      const results = new Set<number>()
+      for (let i = 0; i < 50; i++) {
+        results.add(randomStrategy(boardModel))
+      }
+      for (const field of results) {
+        expect(isEmptyField(boardModel, field as Field)).toBe(true)
+      }
+    })
+
+    it('can return different fields over multiple calls', () => {
+      const boardModel = createInitialBoardModel()
+      const results = new Set<number>()
+      for (let i = 0; i < 50; i++) {
+        results.add(randomStrategy(boardModel))
+      }
+      expect(results.size).toBeGreaterThan(1)
+    })
+
+    it('throws an error when the board is full', () => {
+      const boardModel = placeMoves(
+        [0, 'X'],
+        [1, 'O'],
+        [2, 'X'],
+        [3, 'O'],
+        [4, 'X'],
+        [5, 'O'],
+        [6, 'X'],
+        [7, 'O'],
+        [8, 'X'],
+      )
+      expect(() => randomStrategy(boardModel)).toThrow()
     })
   })
 })

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -1,4 +1,9 @@
-import {createInitialBoardModel, Field, isEmptyField, placeMoves} from './GameModel.ts'
+import {
+  createInitialBoardModel,
+  Field,
+  isEmptyField,
+  placeMoves,
+} from './GameModel.ts'
 import {deterministicStrategy, randomStrategy} from './Strategies.ts'
 
 describe('Strategies', () => {

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -9,3 +9,12 @@ export const deterministicStrategy: Strategy = boardModel => {
   }
   return emptyField
 }
+
+export const randomStrategy: Strategy = boardModel => {
+  const emptyFields = allFields.filter(isEmptyField(boardModel))
+  if (emptyFields.length === 0) {
+    throw new Error('No empty field found in the board model')
+  }
+  const randomIndex = Math.floor(Math.random() * emptyFields.length)
+  return emptyFields[randomIndex]
+}


### PR DESCRIPTION
## Summary

- Add `randomStrategy` in `src/models/Strategies.ts` that picks a random empty field from the board using `Math.random()`
- Export `randomStrategy` alongside the existing `deterministicStrategy`
- Add unit tests in `src/models/Strategies.test.ts` verifying: returns empty field, only returns empty fields, produces different results over multiple calls (non-deterministic), and throws on a full board

Closes #53