### PR TITLE
Allow player to choose between deterministic and random AI strategy

### DIFF
--- a/cypress/e2e/player_starts_game.cy.js
+++ b/cypress/e2e/player_starts_game.cy.js
@@ -16,4 +16,33 @@ describe('Player starts game', () => {
     })
     cy.get('[data-testid="start-new-game-button"]').should('not.exist')
   })
+
+  it('should show deterministic strategy selected by default', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid="strategy-deterministic"]').should('be.checked')
+    cy.get('[data-testid="strategy-random"]').should('not.be.checked')
+  })
+
+  it('should allow selecting the random strategy', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid="strategy-random"]').click()
+    cy.get('[data-testid="strategy-random"]').should('be.checked')
+    cy.get('[data-testid="strategy-deterministic"]').should('not.be.checked')
+  })
+
+  it('should allow switching between strategies', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid="strategy-deterministic"]').should('be.checked')
+
+    cy.get('[data-testid="strategy-random"]').click()
+    cy.get('[data-testid="strategy-random"]').should('be.checked')
+    cy.get('[data-testid="strategy-deterministic"]').should('not.be.checked')
+
+    cy.get('[data-testid="strategy-deterministic"]').click()
+    cy.get('[data-testid="strategy-deterministic"]').should('be.checked')
+    cy.get('[data-testid="strategy-random"]').should('not.be.checked')
+  })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -61,4 +61,36 @@ describe('App', () => {
     const boards = screen.getAllByTestId('board')
     expect(boards).toHaveLength(3)
   })
+
+  it('shows strategy radio buttons with deterministic selected by default', () => {
+    render(<App />)
+
+    const deterministicRadio = screen.getByTestId('strategy-deterministic')
+    const randomRadio = screen.getByTestId('strategy-random')
+
+    expect(deterministicRadio).toBeChecked()
+    expect(randomRadio).not.toBeChecked()
+  })
+
+  it('allows switching to random strategy', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByTestId('strategy-random'))
+
+    expect(screen.getByTestId('strategy-random')).toBeChecked()
+    expect(screen.getByTestId('strategy-deterministic')).not.toBeChecked()
+  })
+
+  it('allows switching back to deterministic strategy', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByTestId('strategy-random'))
+    expect(screen.getByTestId('strategy-random')).toBeChecked()
+
+    await user.click(screen.getByTestId('strategy-deterministic'))
+    expect(screen.getByTestId('strategy-deterministic')).toBeChecked()
+    expect(screen.getByTestId('strategy-random')).not.toBeChecked()
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,21 +3,53 @@ import Game from './components/Game.tsx'
 import clsx from 'clsx'
 import {useState} from 'react'
 import Board from './components/Board.tsx'
+import {strategyMap, StrategyName} from './models/Strategies.ts'
 
 type ShowGameStatus = false | 0 | true
 
 function WelcomePage({
   showGame,
   setShowGame,
+  strategyName,
+  setStrategyName,
 }: {
   showGame: ShowGameStatus
   setShowGame: (arg: ShowGameStatus) => void
+  strategyName: StrategyName
+  setStrategyName: (arg: StrategyName) => void
 }) {
   return (
     <>
       <h1 className="py-6 text-center text-3xl font-bold text-bark">
         Welcome to React Tic Tac Toe
       </h1>
+      <div className="my-4 flex items-center justify-center gap-6">
+        <span className="text-lg text-bark">AI Strategy:</span>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="strategy"
+            value="deterministic"
+            checked={strategyName === 'deterministic'}
+            onChange={() => setStrategyName('deterministic')}
+            data-testid="strategy-deterministic"
+            className="accent-flame"
+          />
+          <span className="text-bark">Deterministic</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="strategy"
+            value="random"
+            checked={strategyName === 'random'}
+            onChange={() => setStrategyName('random')}
+            data-testid="strategy-random"
+            className="accent-flame"
+          />
+          <span className="text-bark">Random</span>
+        </label>
+      </div>
       <div
         className={clsx('my-3 flex justify-center', {
           'transition-transform duration-200 ease-in-out': true,
@@ -55,12 +87,19 @@ function WelcomePage({
 
 function App() {
   const [showGame, setShowGame] = useState<ShowGameStatus>(false)
+  const [strategyName, setStrategyName] =
+    useState<StrategyName>('deterministic')
 
   return (
     <div className="min-h-screen">
       {!showGame && (
         <div className="flex min-h-screen flex-col items-center justify-center px-4">
-          <WelcomePage showGame={showGame} setShowGame={setShowGame} />
+          <WelcomePage
+            showGame={showGame}
+            setShowGame={setShowGame}
+            strategyName={strategyName}
+            setStrategyName={setStrategyName}
+          />
         </div>
       )}
       <div
@@ -69,7 +108,12 @@ function App() {
           'opacity-0': !showGame,
         })}
       >
-        {!!showGame && <Game onReturnToWelcome={() => setShowGame(false)} />}
+        {!!showGame && (
+          <Game
+            strategy={strategyMap[strategyName]}
+            onReturnToWelcome={() => setShowGame(false)}
+          />
+        )}
       </div>
     </div>
   )

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -4,7 +4,12 @@ import {
   isEmptyField,
   placeMoves,
 } from './GameModel.ts'
-import {deterministicStrategy, randomStrategy} from './Strategies.ts'
+import {
+  deterministicStrategy,
+  randomStrategy,
+  strategyMap,
+  StrategyName,
+} from './Strategies.ts'
 
 describe('Strategies', () => {
   describe('deterministicStrategy', () => {
@@ -90,6 +95,23 @@ describe('Strategies', () => {
         [8, 'X'],
       )
       expect(() => randomStrategy(boardModel)).toThrow()
+    })
+  })
+
+  describe('strategyMap', () => {
+    it('maps deterministic to deterministicStrategy', () => {
+      expect(strategyMap.deterministic).toBe(deterministicStrategy)
+    })
+
+    it('maps random to randomStrategy', () => {
+      expect(strategyMap.random).toBe(randomStrategy)
+    })
+
+    it('contains exactly two strategies', () => {
+      const keys = Object.keys(strategyMap) as StrategyName[]
+      expect(keys).toHaveLength(2)
+      expect(keys).toContain('deterministic')
+      expect(keys).toContain('random')
     })
   })
 })

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -2,6 +2,8 @@ import {allFields, BoardModel, Field, isEmptyField} from './GameModel.ts'
 
 export type Strategy = (boardModel: BoardModel) => Field
 
+export type StrategyName = 'deterministic' | 'random'
+
 export const deterministicStrategy: Strategy = boardModel => {
   const emptyField = allFields.find(isEmptyField(boardModel))
   if (emptyField === undefined) {
@@ -17,4 +19,9 @@ export const randomStrategy: Strategy = boardModel => {
   }
   const randomIndex = Math.floor(Math.random() * emptyFields.length)
   return emptyFields[randomIndex]
+}
+
+export const strategyMap: Record<StrategyName, Strategy> = {
+  deterministic: deterministicStrategy,
+  random: randomStrategy,
 }


### PR DESCRIPTION
## Summary

- Added strategy selection UI to the welcome page with radio buttons for "Deterministic" and "Random" AI strategies
- Added `StrategyName` type and `strategyMap` to `Strategies.ts` for mapping strategy names to their implementations
- The selected strategy is passed to the `<Game>` component when starting a new game
- "Deterministic" is selected by default, matching the previous default behavior
- Added unit tests and Cypress E2E tests for the new strategy selection feature

Closes #40