### PR TITLE
[#55] Implement Minimax AI strategy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,18 @@ function WelcomePage({
           />
           <span className="text-bark">Random</span>
         </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="strategy"
+            value="minimax"
+            checked={strategyName === 'minimax'}
+            onChange={() => setStrategyName('minimax')}
+            data-testid="strategy-minimax"
+            className="accent-flame"
+          />
+          <span className="text-bark">Minimax</span>
+        </label>
       </div>
       <div
         className={clsx('my-3 flex justify-center', {

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -2,14 +2,38 @@ import {
   createInitialBoardModel,
   Field,
   isEmptyField,
+  placeMove,
   placeMoves,
+  Piece,
 } from './GameModel.ts'
+import {gameStatus} from './GameStatus.ts'
 import {
   deterministicStrategy,
+  minimaxStrategy,
   randomStrategy,
   strategyMap,
   StrategyName,
 } from './Strategies.ts'
+
+function playGame(
+  board: ReturnType<typeof createInitialBoardModel>,
+  xStrategy: (board: ReturnType<typeof createInitialBoardModel>) => Field,
+): ReturnType<typeof createInitialBoardModel> {
+  let current = board
+  while (gameStatus(current).type === 'Turn') {
+    const player = (gameStatus(current) as {type: 'Turn'; player: Piece}).player
+    if (player === 'O') {
+      current = placeMove(current, [minimaxStrategy(current), 'O'])
+    } else {
+      current = placeMove(current, [xStrategy(current), 'X'])
+    }
+  }
+  return current
+}
+
+function alwaysFirstEmpty(board: ReturnType<typeof createInitialBoardModel>): Field {
+  return deterministicStrategy(board)
+}
 
 describe('Strategies', () => {
   describe('deterministicStrategy', () => {
@@ -98,6 +122,104 @@ describe('Strategies', () => {
     })
   })
 
+  describe('minimaxStrategy', () => {
+    it('picks the center on an empty board', () => {
+      const boardModel = createInitialBoardModel()
+      expect(minimaxStrategy(boardModel)).toEqual(4)
+    })
+
+    it('wins when a winning move is available', () => {
+      const boardModel = placeMoves([0, 'O'], [1, 'O'], [3, 'X'], [4, 'X'])
+      expect(minimaxStrategy(boardModel)).toEqual(2)
+    })
+
+    it('blocks the opponent when they have a winning move', () => {
+      const boardModel = placeMoves([0, 'X'], [1, 'X'], [4, 'O'])
+      expect(minimaxStrategy(boardModel)).toEqual(2)
+    })
+
+    it('prefers winning over blocking', () => {
+      const boardModel = placeMoves(
+        [0, 'O'],
+        [1, 'O'],
+        [3, 'X'],
+        [6, 'X'],
+        [7, 'X'],
+      )
+      expect(minimaxStrategy(boardModel)).toEqual(2)
+    })
+
+    it('takes the only available field', () => {
+      const boardModel = placeMoves(
+        [0, 'X'],
+        [1, 'O'],
+        [2, 'X'],
+        [3, 'O'],
+        [4, 'X'],
+        [5, 'O'],
+        [6, 'O'],
+        [7, 'X'],
+      )
+      expect(minimaxStrategy(boardModel)).toEqual(8)
+    })
+
+    it('forces a draw from a blocked position', () => {
+      const boardModel = placeMoves([0, 'X'], [2, 'X'], [4, 'O'])
+      const result = minimaxStrategy(boardModel)
+      const nextBoard = placeMove(boardModel, [result, 'O'])
+      const finalBoard = playGame(nextBoard, alwaysFirstEmpty)
+      const finalStatus = gameStatus(finalBoard)
+      expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+    })
+
+    it('never loses from any starting move as O', () => {
+      const allStartingMoves: Field[] = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      for (const start of allStartingMoves) {
+        const boardModel = placeMoves([start, 'X'])
+        const finalBoard = playGame(boardModel, alwaysFirstEmpty)
+        const finalStatus = gameStatus(finalBoard)
+        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+      }
+    })
+
+    it('never loses playing full games from empty board', () => {
+      const allMoves: Field[] = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      for (const firstMove of allMoves) {
+        let board = createInitialBoardModel()
+        board = placeMove(board, [firstMove, 'X'])
+
+        while (gameStatus(board).type === 'Turn') {
+          const currentPlayer = (gameStatus(board) as {type: 'Turn'; player: 'X' | 'O'}).player
+          if (currentPlayer === 'O') {
+            const move = minimaxStrategy(board)
+            board = placeMove(board, [move, 'O'])
+          } else {
+            const emptyFields = allMoves.filter(f => isEmptyField(board, f as Field)) as Field[]
+            board = placeMove(board, [emptyFields[0], 'X'])
+          }
+        }
+
+        const finalStatus = gameStatus(board)
+        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+      }
+    })
+
+    it('throws an error when the board is full', () => {
+      const boardModel = placeMoves(
+        [0, 'X'],
+        [1, 'O'],
+        [2, 'X'],
+        [3, 'O'],
+        [4, 'X'],
+        [5, 'O'],
+        [6, 'O'],
+        [7, 'X'],
+        [8, 'X'],
+      )
+      expect(() => minimaxStrategy(boardModel)).toThrow()
+    })
+  })
+
   describe('strategyMap', () => {
     it('maps deterministic to deterministicStrategy', () => {
       expect(strategyMap.deterministic).toBe(deterministicStrategy)
@@ -107,11 +229,16 @@ describe('Strategies', () => {
       expect(strategyMap.random).toBe(randomStrategy)
     })
 
-    it('contains exactly two strategies', () => {
+    it('maps minimax to minimaxStrategy', () => {
+      expect(strategyMap.minimax).toBe(minimaxStrategy)
+    })
+
+    it('contains exactly three strategies', () => {
       const keys = Object.keys(strategyMap) as StrategyName[]
-      expect(keys).toHaveLength(2)
+      expect(keys).toHaveLength(3)
       expect(keys).toContain('deterministic')
       expect(keys).toContain('random')
+      expect(keys).toContain('minimax')
     })
   })
 })

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -31,7 +31,9 @@ function playGame(
   return current
 }
 
-function alwaysFirstEmpty(board: ReturnType<typeof createInitialBoardModel>): Field {
+function alwaysFirstEmpty(
+  board: ReturnType<typeof createInitialBoardModel>,
+): Field {
   return deterministicStrategy(board)
 }
 
@@ -169,7 +171,9 @@ describe('Strategies', () => {
       const nextBoard = placeMove(boardModel, [result, 'O'])
       const finalBoard = playGame(nextBoard, alwaysFirstEmpty)
       const finalStatus = gameStatus(finalBoard)
-      expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+      expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(
+        false,
+      )
     })
 
     it('never loses from any starting move as O', () => {
@@ -178,7 +182,9 @@ describe('Strategies', () => {
         const boardModel = placeMoves([start, 'X'])
         const finalBoard = playGame(boardModel, alwaysFirstEmpty)
         const finalStatus = gameStatus(finalBoard)
-        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(
+          false,
+        )
       }
     })
 
@@ -189,18 +195,24 @@ describe('Strategies', () => {
         board = placeMove(board, [firstMove, 'X'])
 
         while (gameStatus(board).type === 'Turn') {
-          const currentPlayer = (gameStatus(board) as {type: 'Turn'; player: 'X' | 'O'}).player
+          const currentPlayer = (
+            gameStatus(board) as {type: 'Turn'; player: 'X' | 'O'}
+          ).player
           if (currentPlayer === 'O') {
             const move = minimaxStrategy(board)
             board = placeMove(board, [move, 'O'])
           } else {
-            const emptyFields = allMoves.filter(f => isEmptyField(board, f as Field)) as Field[]
+            const emptyFields = allMoves.filter(f =>
+              isEmptyField(board, f as Field),
+            ) as Field[]
             board = placeMove(board, [emptyFields[0], 'X'])
           }
         }
 
         const finalStatus = gameStatus(board)
-        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(false)
+        expect(finalStatus.type === 'Won' && finalStatus.player === 'X').toBe(
+          false,
+        )
       }
     })
 

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -1,8 +1,65 @@
-import {allFields, BoardModel, Field, isEmptyField} from './GameModel.ts'
+import {allFields, BoardModel, Field, isEmptyField, placeMove} from './GameModel.ts'
+import {gameStatus} from './GameStatus.ts'
 
 export type Strategy = (boardModel: BoardModel) => Field
 
-export type StrategyName = 'deterministic' | 'random'
+export type StrategyName = 'deterministic' | 'random' | 'minimax'
+
+function minimaxScore(boardModel: BoardModel, isMaximizing: boolean): number {
+  const status = gameStatus(boardModel)
+
+  if (status.type === 'Won') {
+    return status.player === 'O' ? 1 : -1
+  }
+
+  if (status.type === 'Draw') {
+    return 0
+  }
+
+  const emptyFields = allFields.filter(isEmptyField(boardModel))
+
+  if (isMaximizing) {
+    let bestScore = -Infinity
+    for (const field of emptyFields) {
+      const newBoard = placeMove(boardModel, [field, 'O'])
+      const score = minimaxScore(newBoard, false)
+      bestScore = Math.max(bestScore, score)
+    }
+    return bestScore
+  } else {
+    let bestScore = Infinity
+    for (const field of emptyFields) {
+      const newBoard = placeMove(boardModel, [field, 'X'])
+      const score = minimaxScore(newBoard, true)
+      bestScore = Math.min(bestScore, score)
+    }
+    return bestScore
+  }
+}
+
+export const minimaxStrategy: Strategy = boardModel => {
+  const emptyFields = allFields.filter(isEmptyField(boardModel))
+  if (emptyFields.length === 0) {
+    throw new Error('No empty field found in the board model')
+  }
+
+  const preferredOrder: Field[] = [4, 0, 2, 8, 6, 1, 3, 5, 7]
+  const orderedEmptyFields = preferredOrder.filter(f => emptyFields.includes(f))
+
+  let bestScore = -Infinity
+  let bestField = orderedEmptyFields[0]
+
+  for (const field of orderedEmptyFields) {
+    const newBoard = placeMove(boardModel, [field, 'O'])
+    const score = minimaxScore(newBoard, false)
+    if (score > bestScore) {
+      bestScore = score
+      bestField = field
+    }
+  }
+
+  return bestField
+}
 
 export const deterministicStrategy: Strategy = boardModel => {
   const emptyField = allFields.find(isEmptyField(boardModel))
@@ -24,4 +81,5 @@ export const randomStrategy: Strategy = boardModel => {
 export const strategyMap: Record<StrategyName, Strategy> = {
   deterministic: deterministicStrategy,
   random: randomStrategy,
+  minimax: minimaxStrategy,
 }

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -1,4 +1,10 @@
-import {allFields, BoardModel, Field, isEmptyField, placeMove} from './GameModel.ts'
+import {
+  allFields,
+  BoardModel,
+  Field,
+  isEmptyField,
+  placeMove,
+} from './GameModel.ts'
 import {gameStatus} from './GameStatus.ts'
 
 export type Strategy = (boardModel: BoardModel) => Field


### PR DESCRIPTION
## Summary

- Added `minimaxStrategy` to `src/models/Strategies.ts` — an unbeatable AI opponent that recursively evaluates all possible game states using the minimax algorithm
- O (AI) is the maximizing player (+1 for O win), X (human) is the minimizing player (-1 for X win), draws score 0
- Moves are evaluated in center > corners > edges order to prefer stronger opening positions when scores are equal
- Added `'minimax'` to `StrategyName` union type and `strategyMap`
- Added comprehensive tests in `src/models/Strategies.test.ts`:
  - Picks center on empty board
  - Wins when a winning move is available
  - Blocks opponent when they have a winning move
  - Prefers winning over blocking
  - Takes the only available field
  - Forces a draw from blocked positions
  - Never loses from any starting position (full game simulation)
  - Throws on full board

Closes #55