### PR TITLE
Fix layout shift when game-end dialog closes - add persistent navigation button

### DIFF
--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -56,4 +56,21 @@ describe('Button', () => {
     expect(button).toHaveClass('py-4')
     expect(button).toHaveClass('shadow-xl')
   })
+
+  it('applies primary variant styles by default', () => {
+    render(<Button>Click me</Button>)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('bg-flame')
+    expect(button).toHaveClass('text-white')
+  })
+
+  it('applies secondary variant styles when variant is secondary', () => {
+    render(<Button variant="secondary">Cancel</Button>)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('border-flame')
+    expect(button).toHaveClass('bg-cream')
+    expect(button).toHaveClass('text-flame')
+  })
 })

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,12 +2,26 @@ import clsx from 'clsx'
 import {ButtonHTMLAttributes} from 'react'
 
 type ButtonSize = 'normal' | 'large'
+type ButtonVariant = 'primary' | 'secondary'
 
-const classes = (size: ButtonSize) => {
-  const baseStyles = 'bg-flame text-white font-semibold'
-  const hoverStyles = 'hover:bg-flame-dark'
+const classes = (size: ButtonSize, variant: ButtonVariant = 'primary') => {
   const focusStyles =
     'focus-visible:outline-none focus-visible:ring focus-visible:ring-flame/50'
+
+  const variantStyles = (variant: ButtonVariant) => {
+    if (variant === 'secondary') {
+      return clsx(
+        'border-2 border-flame bg-cream font-semibold text-flame',
+        'hover:bg-flame/10',
+        focusStyles,
+      )
+    }
+    return clsx(
+      'bg-flame font-semibold text-white',
+      'hover:bg-flame-dark',
+      focusStyles,
+    )
+  }
 
   const stylesForSize = (size: ButtonSize) => {
     if (size === 'normal') {
@@ -17,16 +31,18 @@ const classes = (size: ButtonSize) => {
     }
   }
 
-  return clsx(baseStyles, hoverStyles, focusStyles, stylesForSize(size))
+  return clsx(variantStyles(variant), stylesForSize(size))
 }
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   dataTestid?: string
   size?: ButtonSize
+  variant?: ButtonVariant
 }
 
 function Button({
   size = 'normal',
+  variant = 'primary',
   children,
   className,
   dataTestid,
@@ -34,7 +50,7 @@ function Button({
 }: ButtonProps) {
   return (
     <button
-      className={clsx(classes(size), className)}
+      className={clsx(classes(size, variant), className)}
       data-testid={dataTestid}
       {...props}
     >

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -595,9 +595,7 @@ describe('Game', () => {
       expect(screen.getByTestId('abort-dialog-message')).toHaveTextContent(
         'Are you sure you want to quit the game?',
       )
-      expect(
-        screen.getByRole('button', {name: 'Cancel'}),
-      ).toBeInTheDocument()
+      expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument()
       expect(
         screen.getByRole('button', {name: 'Quit Game'}),
       ).toBeInTheDocument()
@@ -625,7 +623,9 @@ describe('Game', () => {
       await user.click(screen.getByRole('button', {name: 'Cancel'}))
 
       await waitFor(() =>
-        expect(screen.queryByTestId('abort-dialog-message')).not.toBeInTheDocument(),
+        expect(
+          screen.queryByTestId('abort-dialog-message'),
+        ).not.toBeInTheDocument(),
       )
 
       expect(onReturnToWelcome).not.toHaveBeenCalled()

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -150,7 +150,7 @@ describe('Game', () => {
         )
       })
 
-      it('calls onReturnToWelcome when the Return to Welcome Page button is clicked', async () => {
+      it('calls onReturnToWelcome when the Return to Welcome Page button is clicked after game ends', async () => {
         const user = userEvent.setup()
         const onReturnToWelcome = vi.fn()
         const boardModel = placeMoves(
@@ -168,20 +168,24 @@ describe('Game', () => {
           />,
         )
 
+        // Game is already won, so button shows "Return to Welcome Page"
+        expect(
+          screen.getByRole('button', {name: 'Return to Welcome Page'}),
+        ).toBeInTheDocument()
+
         await waitFor(
           () =>
             expect(screen.getByTestId('game-ends-message')).toBeInTheDocument(),
           {timeout: 3000},
         )
 
-        // Button is not yet visible while the dialog is open
+        // After game ends, button still says "Return to Welcome Page"
         expect(
-          screen.queryByRole('button', {name: 'Return to Welcome Page'}),
-        ).not.toBeInTheDocument()
+          screen.getByRole('button', {name: 'Return to Welcome Page'}),
+        ).toBeInTheDocument()
 
         await user.click(screen.getByRole('button', {name: 'Close'}))
 
-        // Button appears below the game after closing the dialog
         await user.click(
           screen.getByRole('button', {name: 'Return to Welcome Page'}),
         )
@@ -189,7 +193,7 @@ describe('Game', () => {
         expect(onReturnToWelcome).toHaveBeenCalledOnce()
       })
 
-      it('does not show a Return to Welcome Page button when onReturnToWelcome is not provided', async () => {
+      it('does not show navigation buttons when onReturnToWelcome is not provided', async () => {
         const user = userEvent.setup()
         const boardModel = placeMoves(
           [0, 'X'],
@@ -200,6 +204,10 @@ describe('Game', () => {
         )
 
         render(<Game initialBoardModel={boardModel} />)
+
+        expect(
+          screen.queryByRole('button', {name: 'Abort Game'}),
+        ).not.toBeInTheDocument()
 
         await waitFor(
           () =>
@@ -553,6 +561,111 @@ describe('Game', () => {
       )
 
       expect(onGameComplete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('navigation button', () => {
+    it('shows Abort Game button during gameplay when onReturnToWelcome is provided', () => {
+      const onReturnToWelcome = vi.fn()
+      render(<Game onReturnToWelcome={onReturnToWelcome} />)
+
+      expect(
+        screen.getByRole('button', {name: 'Abort Game'}),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', {name: 'Return to Welcome Page'}),
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show Abort Game button when onReturnToWelcome is not provided', () => {
+      render(<Game />)
+
+      expect(
+        screen.queryByRole('button', {name: 'Abort Game'}),
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows confirmation dialog when Abort Game is clicked', async () => {
+      const user = userEvent.setup()
+      const onReturnToWelcome = vi.fn()
+      render(<Game onReturnToWelcome={onReturnToWelcome} />)
+
+      await user.click(screen.getByRole('button', {name: 'Abort Game'}))
+
+      expect(screen.getByTestId('abort-dialog-message')).toHaveTextContent(
+        'Are you sure you want to quit the game?',
+      )
+      expect(
+        screen.getByRole('button', {name: 'Cancel'}),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {name: 'Quit Game'}),
+      ).toBeInTheDocument()
+    })
+
+    it('calls onReturnToWelcome when Quit Game is clicked in abort dialog', async () => {
+      const user = userEvent.setup()
+      const onReturnToWelcome = vi.fn()
+      render(<Game onReturnToWelcome={onReturnToWelcome} />)
+
+      await user.click(screen.getByRole('button', {name: 'Abort Game'}))
+      await user.click(screen.getByRole('button', {name: 'Quit Game'}))
+
+      expect(onReturnToWelcome).toHaveBeenCalledOnce()
+    })
+
+    it('closes abort dialog when Cancel is clicked and returns to game', async () => {
+      const user = userEvent.setup()
+      const onReturnToWelcome = vi.fn()
+      render(<Game onReturnToWelcome={onReturnToWelcome} />)
+
+      await user.click(screen.getByRole('button', {name: 'Abort Game'}))
+      expect(screen.getByTestId('abort-dialog-message')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', {name: 'Cancel'}))
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('abort-dialog-message')).not.toBeInTheDocument(),
+      )
+
+      expect(onReturnToWelcome).not.toHaveBeenCalled()
+      // Game is still visible
+      expect(screen.getByTestId('board')).toBeInTheDocument()
+    })
+
+    it('changes button from Abort Game to Return to Welcome Page when game ends', async () => {
+      const onReturnToWelcome = vi.fn()
+      const boardModel = placeMoves(
+        [0, 'X'],
+        [4, 'O'],
+        [1, 'X'],
+        [6, 'O'],
+        [2, 'X'],
+      )
+
+      render(
+        <Game
+          initialBoardModel={boardModel}
+          onReturnToWelcome={onReturnToWelcome}
+        />,
+      )
+
+      // Game is already won, so button says "Return to Welcome Page"
+      expect(
+        screen.getByRole('button', {name: 'Return to Welcome Page'}),
+      ).toBeInTheDocument()
+
+      // Wait for the game end dialog
+      await waitFor(
+        () =>
+          expect(screen.getByTestId('game-ends-message')).toBeInTheDocument(),
+        {timeout: 3000},
+      )
+
+      // After game ends, button still says "Return to Welcome Page"
+      expect(
+        screen.getByRole('button', {name: 'Return to Welcome Page'}),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -158,11 +158,7 @@ export function Game({
           {onReturnToWelcome && (
             <div className="pb-2">
               <Button
-                variant={
-                  isTurnStatus(status) || showGameEndDialog
-                    ? 'secondary'
-                    : 'primary'
-                }
+                variant={winMessage !== null ? 'primary' : 'secondary'}
                 onClick={
                   isTurnStatus(status)
                     ? () => setShowAbortDialog(true)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -66,6 +66,8 @@ export function Game({
   const [isAIThinking, setIsAIThinking] = useState(false)
   const [showNotAllowedCursor, setShowNotAllowedCursor] = useState(false)
   const [lastMoveField, setLastMoveField] = useState<Field | null>(null)
+  const [showAbortDialog, setShowAbortDialog] = useState(false)
+  const [abortDialogClosing, setAbortDialogClosing] = useState(false)
 
   useCypress(boardModel, setBoardModel)
 
@@ -153,10 +155,18 @@ export function Game({
           <h1 className="py-4 text-center text-2xl font-bold text-bark sm:py-6 sm:text-3xl">
             {winMessage ?? 'Have fun with this game!'}
           </h1>
-          {winMessage !== null && onReturnToWelcome && (
+          {onReturnToWelcome && (
             <div className="pb-2">
-              <Button onClick={onReturnToWelcome}>
-                Return to Welcome Page
+              <Button
+                onClick={
+                  isTurnStatus(status)
+                    ? () => setShowAbortDialog(true)
+                    : onReturnToWelcome
+                }
+              >
+                {isTurnStatus(status)
+                  ? 'Abort Game'
+                  : 'Return to Welcome Page'}
               </Button>
             </div>
           )}
@@ -244,6 +254,67 @@ export function Game({
                 >
                   Close
                 </Button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {showAbortDialog && (
+        <>
+          <div
+            className={clsx(
+              'fixed inset-0 z-50 bg-bark/60',
+              abortDialogClosing
+                ? 'animate-backdrop-fade-out'
+                : 'animate-backdrop-fade-in',
+            )}
+          ></div>
+          <div className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform">
+            <div
+              className={clsx(
+                'min-w-[280px] overflow-hidden rounded-2xl border border-wood/30 bg-cream shadow-2xl',
+                abortDialogClosing
+                  ? 'animate-dialog-fade-out'
+                  : 'animate-dialog-scale-in',
+              )}
+            >
+              <div className="h-2 bg-wood/40" />
+              <div className="px-8 pb-8 pt-6 text-center">
+                <div className="mb-3 text-5xl" aria-hidden="true">
+                  ⚠️
+                </div>
+                <p
+                  className="mb-6 text-xl font-bold text-bark"
+                  data-testid="abort-dialog-message"
+                >
+                  Are you sure you want to quit the game?
+                </p>
+                <div className="flex gap-3">
+                  <Button
+                    className="flex-1"
+                    onClick={() => {
+                      setAbortDialogClosing(true)
+                      setTimeout(() => {
+                        setShowAbortDialog(false)
+                        setAbortDialogClosing(false)
+                      }, 500)
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="large"
+                    className="flex-1"
+                    onClick={() => {
+                      setShowAbortDialog(false)
+                      setAbortDialogClosing(false)
+                      onReturnToWelcome?.()
+                    }}
+                  >
+                    Quit Game
+                  </Button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -158,7 +158,11 @@ export function Game({
           {onReturnToWelcome && (
             <div className="pb-2">
               <Button
-                variant="secondary"
+                variant={
+                  isTurnStatus(status) || showGameEndDialog
+                    ? 'secondary'
+                    : 'primary'
+                }
                 onClick={
                   isTurnStatus(status)
                     ? () => setShowAbortDialog(true)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -291,7 +291,7 @@ export function Game({
                 </p>
                 <div className="flex gap-3">
                   <Button
-variant={isTurnStatus(status) ? 'secondary' : 'primary'}
+                    variant={isTurnStatus(status) ? 'secondary' : 'primary'}
                     className="flex-1"
                     onClick={() => {
                       setAbortDialogClosing(true)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -158,6 +158,7 @@ export function Game({
           {onReturnToWelcome && (
             <div className="pb-2">
               <Button
+                variant="secondary"
                 onClick={
                   isTurnStatus(status)
                     ? () => setShowAbortDialog(true)
@@ -290,6 +291,7 @@ export function Game({
                 </p>
                 <div className="flex gap-3">
                   <Button
+                    variant="secondary"
                     className="flex-1"
                     onClick={() => {
                       setAbortDialogClosing(true)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -164,9 +164,7 @@ export function Game({
                     : onReturnToWelcome
                 }
               >
-                {isTurnStatus(status)
-                  ? 'Abort Game'
-                  : 'Return to Welcome Page'}
+                {isTurnStatus(status) ? 'Abort Game' : 'Return to Welcome Page'}
               </Button>
             </div>
           )}

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -291,7 +291,7 @@ export function Game({
                 </p>
                 <div className="flex gap-3">
                   <Button
-                    variant="secondary"
+variant={isTurnStatus(status) ? 'secondary' : 'primary'}
                     className="flex-1"
                     onClick={() => {
                       setAbortDialogClosing(true)


### PR DESCRIPTION
## Summary

- Replace the conditional "Return to Welcome Page" button (which only appeared after the game-end dialog closed) with a persistent navigation button visible throughout the game lifecycle
- During gameplay: button shows **"Abort Game"** and opens a confirmation dialog asking "Are you sure you want to quit the game?"
- After game ends: button shows **"Return to Welcome Page"** and exits immediately without confirmation
- This eliminates the jarring layout shift that occurred when the game-end dialog closed and the button suddenly appeared

## Changes

- **`Game.tsx`**: Added `showAbortDialog` and `abortDialogClosing` state; changed navigation button to always render when `onReturnToWelcome` is provided, with label/behavior based on game status; added abort confirmation dialog with Cancel/Quit Game buttons
- **`Game.test.tsx`**: Updated existing tests for new button behavior; renamed test for clarity; added test suite for abort dialog functionality (shows button during gameplay, shows confirmation dialog, calls onReturnToWelcome on quit, cancels and returns to game, button label transitions on game end)

Closes #60