### PR TITLE
Add new AI strategy: 'Mostly random'

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -78,9 +78,11 @@ describe('App', () => {
 
     const deterministicRadio = screen.getByTestId('strategy-deterministic')
     const randomRadio = screen.getByTestId('strategy-random')
+    const mostlyRandomRadio = screen.getByTestId('strategy-mostly-random')
 
     expect(deterministicRadio).toBeChecked()
     expect(randomRadio).not.toBeChecked()
+    expect(mostlyRandomRadio).not.toBeChecked()
   })
 
   it('allows switching to random strategy', async () => {
@@ -90,6 +92,16 @@ describe('App', () => {
     await user.click(screen.getByTestId('strategy-random'))
 
     expect(screen.getByTestId('strategy-random')).toBeChecked()
+    expect(screen.getByTestId('strategy-deterministic')).not.toBeChecked()
+  })
+
+  it('allows switching to mostly random strategy', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByTestId('strategy-mostly-random'))
+
+    expect(screen.getByTestId('strategy-mostly-random')).toBeChecked()
     expect(screen.getByTestId('strategy-deterministic')).not.toBeChecked()
   })
 
@@ -103,6 +115,7 @@ describe('App', () => {
     await user.click(screen.getByTestId('strategy-deterministic'))
     expect(screen.getByTestId('strategy-deterministic')).toBeChecked()
     expect(screen.getByTestId('strategy-random')).not.toBeChecked()
+    expect(screen.getByTestId('strategy-mostly-random')).not.toBeChecked()
   })
 
   it('does not show Clear History button when no games have been played', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,18 @@ function WelcomePage({
           <input
             type="radio"
             name="strategy"
+            value="mostlyRandom"
+            checked={strategyName === 'mostlyRandom'}
+            onChange={() => setStrategyName('mostlyRandom')}
+            data-testid="strategy-mostly-random"
+            className="accent-flame"
+          />
+          <span className="text-bark">Mostly random</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="strategy"
             value="minimax"
             checked={strategyName === 'minimax'}
             onChange={() => setStrategyName('minimax')}

--- a/src/models/PastGame.test.ts
+++ b/src/models/PastGame.test.ts
@@ -95,5 +95,9 @@ describe('PastGame', () => {
     it('capitalizes minimax', () => {
       expect(strategyLabel('minimax')).toEqual('Minimax')
     })
+
+    it('labels mostlyRandom as Mostly random', () => {
+      expect(strategyLabel('mostlyRandom')).toEqual('Mostly random')
+    })
   })
 })

--- a/src/models/PastGame.ts
+++ b/src/models/PastGame.ts
@@ -31,5 +31,11 @@ export function resultLabel(result: PastGameResult): string {
 }
 
 export function strategyLabel(strategy: StrategyName): string {
-  return strategy.charAt(0).toUpperCase() + strategy.slice(1)
+  const labels: Record<StrategyName, string> = {
+    deterministic: 'Deterministic',
+    random: 'Random',
+    mostlyRandom: 'Mostly random',
+    minimax: 'Minimax',
+  }
+  return labels[strategy]
 }

--- a/src/models/Strategies.test.ts
+++ b/src/models/Strategies.test.ts
@@ -1,3 +1,4 @@
+import {vi} from 'vitest'
 import {
   createInitialBoardModel,
   Field,
@@ -10,6 +11,7 @@ import {gameStatus} from './GameStatus.ts'
 import {
   deterministicStrategy,
   minimaxStrategy,
+  mostlyRandomStrategy,
   randomStrategy,
   strategyMap,
   StrategyName,
@@ -232,6 +234,227 @@ describe('Strategies', () => {
     })
   })
 
+  describe('mostlyRandomStrategy', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    describe('Priority 1: Immediate Win', () => {
+      it('plays the winning move when AI can win directly', () => {
+        const boardModel = placeMoves([0, 'O'], [1, 'O'], [3, 'X'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(2)
+      })
+
+      it('plays the winning move when AI has two in a row (column)', () => {
+        const boardModel = placeMoves([0, 'O'], [3, 'O'], [1, 'X'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(6)
+      })
+
+      it('plays the winning move when AI has two in a diagonal', () => {
+        const boardModel = placeMoves([0, 'O'], [4, 'O'], [1, 'X'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(8)
+      })
+
+      it('picks from available winning moves when multiple exist', () => {
+        const boardModel = placeMoves(
+          [0, 'O'],
+          [1, 'O'],
+          [4, 'O'],
+          [3, 'X'],
+          [6, 'X'],
+        )
+        const winningMoves: Field[] = [2, 7, 8]
+        for (let i = 0; i < 20; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          expect(winningMoves).toContain(result)
+        }
+      })
+    })
+
+    describe('Priority 2: Block Opponent', () => {
+      it('blocks the opponent when they can win on next move', () => {
+        const boardModel = placeMoves([0, 'X'], [1, 'X'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(2)
+      })
+
+      it('blocks the opponent column win', () => {
+        const boardModel = placeMoves([0, 'X'], [3, 'X'], [4, 'O'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(6)
+      })
+
+      it('blocks the opponent diagonal win', () => {
+        const boardModel = placeMoves([2, 'X'], [4, 'X'], [0, 'O'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(result).toEqual(6)
+      })
+    })
+
+    describe('Priority 3: Conflict Resolution', () => {
+      it('randomly chooses between winning and blocking when both apply', () => {
+        const boardModel = placeMoves(
+          [0, 'O'],
+          [1, 'O'],
+          [3, 'X'],
+          [6, 'X'],
+          [7, 'X'],
+        )
+        const results = new Set<number>()
+        for (let i = 0; i < 100; i++) {
+          results.add(mostlyRandomStrategy(boardModel))
+        }
+        expect(results.has(2)).toBe(true)
+      })
+
+      it('can choose blocking move over winning move', () => {
+        const boardModel = placeMoves(
+          [0, 'O'],
+          [1, 'O'],
+          [3, 'X'],
+          [6, 'X'],
+          [7, 'X'],
+        )
+        let choseBlock = false
+        for (let i = 0; i < 100; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          if (result === 8) {
+            choseBlock = true
+          }
+        }
+        expect(choseBlock).toBe(true)
+      })
+
+      it('can choose winning move over blocking move', () => {
+        const boardModel = placeMoves(
+          [0, 'O'],
+          [1, 'O'],
+          [3, 'X'],
+          [6, 'X'],
+          [7, 'X'],
+        )
+        let choseWin = false
+        for (let i = 0; i < 100; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          if (result === 2) {
+            choseWin = true
+          }
+        }
+        expect(choseWin).toBe(true)
+      })
+
+      it('returns a valid field when conflict occurs', () => {
+        const boardModel = placeMoves(
+          [0, 'O'],
+          [1, 'O'],
+          [3, 'X'],
+          [6, 'X'],
+          [7, 'X'],
+        )
+        for (let i = 0; i < 50; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          expect(isEmptyField(boardModel, result)).toBe(true)
+          expect([2, 8]).toContain(result)
+        }
+      })
+    })
+
+    describe('Priority 4: Random Move', () => {
+      it('plays a random valid move when no immediate threats', () => {
+        const boardModel = createInitialBoardModel()
+        const result = mostlyRandomStrategy(boardModel)
+        expect(isEmptyField(boardModel, result)).toBe(true)
+      })
+
+      it('can return different fields over multiple calls on empty board', () => {
+        const boardModel = createInitialBoardModel()
+        const results = new Set<number>()
+        for (let i = 0; i < 50; i++) {
+          results.add(mostlyRandomStrategy(boardModel))
+        }
+        expect(results.size).toBeGreaterThan(1)
+      })
+
+      it('plays randomly on opening move with no center/corner preference', () => {
+        const boardModel = createInitialBoardModel()
+        const cornerCount = [0, 2, 6, 8].length
+        let cornerHits = 0
+        const iterations = 500
+        for (let i = 0; i < iterations; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          if ([0, 2, 6, 8].includes(result)) cornerHits++
+        }
+        const cornerRatio = cornerHits / iterations
+        const expectedRatio = cornerCount / 9
+        expect(cornerRatio).toBeGreaterThan(expectedRatio - 0.15)
+        expect(cornerRatio).toBeLessThan(expectedRatio + 0.15)
+      })
+
+      it('plays a random valid move on a partially filled board with no threats', () => {
+        const boardModel = placeMoves([4, 'X'], [0, 'O'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect(isEmptyField(boardModel, result)).toBe(true)
+      })
+
+      it('returns different results over multiple calls with no threats', () => {
+        const boardModel = placeMoves([4, 'X'], [0, 'O'])
+        const results = new Set<number>()
+        for (let i = 0; i < 50; i++) {
+          results.add(mostlyRandomStrategy(boardModel))
+        }
+        expect(results.size).toBeGreaterThan(1)
+      })
+    })
+
+    describe('Edge cases', () => {
+      it('takes the only available field', () => {
+        const boardModel = placeMoves(
+          [0, 'X'],
+          [1, 'O'],
+          [2, 'X'],
+          [3, 'O'],
+          [4, 'X'],
+          [5, 'O'],
+          [6, 'O'],
+          [7, 'X'],
+        )
+        expect(mostlyRandomStrategy(boardModel)).toEqual(8)
+      })
+
+      it('throws an error when the board is full', () => {
+        const boardModel = placeMoves(
+          [0, 'X'],
+          [1, 'O'],
+          [2, 'X'],
+          [3, 'O'],
+          [4, 'X'],
+          [5, 'O'],
+          [6, 'X'],
+          [7, 'O'],
+          [8, 'X'],
+        )
+        expect(() => mostlyRandomStrategy(boardModel)).toThrow()
+      })
+
+      it('always returns a valid empty field', () => {
+        const boardModel = placeMoves([0, 'X'], [4, 'O'])
+        for (let i = 0; i < 20; i++) {
+          const result = mostlyRandomStrategy(boardModel)
+          expect(isEmptyField(boardModel, result as Field)).toBe(true)
+        }
+      })
+
+      it('blocks when opponent has two winning threats', () => {
+        const boardModel = placeMoves([0, 'X'], [4, 'X'], [1, 'O'])
+        const result = mostlyRandomStrategy(boardModel)
+        expect([2, 8]).toContain(result)
+      })
+    })
+  })
+
   describe('strategyMap', () => {
     it('maps deterministic to deterministicStrategy', () => {
       expect(strategyMap.deterministic).toBe(deterministicStrategy)
@@ -241,15 +464,20 @@ describe('Strategies', () => {
       expect(strategyMap.random).toBe(randomStrategy)
     })
 
+    it('maps mostlyRandom to mostlyRandomStrategy', () => {
+      expect(strategyMap.mostlyRandom).toBe(mostlyRandomStrategy)
+    })
+
     it('maps minimax to minimaxStrategy', () => {
       expect(strategyMap.minimax).toBe(minimaxStrategy)
     })
 
-    it('contains exactly three strategies', () => {
+    it('contains exactly four strategies', () => {
       const keys = Object.keys(strategyMap) as StrategyName[]
-      expect(keys).toHaveLength(3)
+      expect(keys).toHaveLength(4)
       expect(keys).toContain('deterministic')
       expect(keys).toContain('random')
+      expect(keys).toContain('mostlyRandom')
       expect(keys).toContain('minimax')
     })
   })

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -10,7 +10,11 @@ import {gameStatus} from './GameStatus.ts'
 
 export type Strategy = (boardModel: BoardModel) => Field
 
-export type StrategyName = 'deterministic' | 'random' | 'mostlyRandom' | 'minimax'
+export type StrategyName =
+  | 'deterministic'
+  | 'random'
+  | 'mostlyRandom'
+  | 'minimax'
 
 function minimaxScore(boardModel: BoardModel, isMaximizing: boolean): number {
   const status = gameStatus(boardModel)

--- a/src/models/Strategies.ts
+++ b/src/models/Strategies.ts
@@ -3,13 +3,14 @@ import {
   BoardModel,
   Field,
   isEmptyField,
+  Piece,
   placeMove,
 } from './GameModel.ts'
 import {gameStatus} from './GameStatus.ts'
 
 export type Strategy = (boardModel: BoardModel) => Field
 
-export type StrategyName = 'deterministic' | 'random' | 'minimax'
+export type StrategyName = 'deterministic' | 'random' | 'mostlyRandom' | 'minimax'
 
 function minimaxScore(boardModel: BoardModel, isMaximizing: boolean): number {
   const status = gameStatus(boardModel)
@@ -84,8 +85,47 @@ export const randomStrategy: Strategy = boardModel => {
   return emptyFields[randomIndex]
 }
 
+function findWinningMoves(boardModel: BoardModel, player: Piece): Field[] {
+  const emptyFields = allFields.filter(isEmptyField(boardModel))
+  return emptyFields.filter(field => {
+    const newBoard = placeMove(boardModel, [field, player])
+    const status = gameStatus(newBoard)
+    return status.type === 'Won' && status.player === player
+  })
+}
+
+export const mostlyRandomStrategy: Strategy = boardModel => {
+  const emptyFields = allFields.filter(isEmptyField(boardModel))
+  if (emptyFields.length === 0) {
+    throw new Error('No empty field found in the board model')
+  }
+
+  const aiWinningMoves = findWinningMoves(boardModel, 'O')
+  const blockMoves = findWinningMoves(boardModel, 'X')
+
+  if (aiWinningMoves.length > 0 && blockMoves.length > 0) {
+    if (Math.random() < 0.5) {
+      return aiWinningMoves[Math.floor(Math.random() * aiWinningMoves.length)]
+    } else {
+      return blockMoves[Math.floor(Math.random() * blockMoves.length)]
+    }
+  }
+
+  if (aiWinningMoves.length > 0) {
+    return aiWinningMoves[Math.floor(Math.random() * aiWinningMoves.length)]
+  }
+
+  if (blockMoves.length > 0) {
+    return blockMoves[Math.floor(Math.random() * blockMoves.length)]
+  }
+
+  const randomIndex = Math.floor(Math.random() * emptyFields.length)
+  return emptyFields[randomIndex]
+}
+
 export const strategyMap: Record<StrategyName, Strategy> = {
   deterministic: deterministicStrategy,
   random: randomStrategy,
+  mostlyRandom: mostlyRandomStrategy,
   minimax: minimaxStrategy,
 }


### PR DESCRIPTION
## Summary

- Implements a new "Mostly random" AI strategy (issue #62) that sits between Random and Minimax in difficulty
- Priority logic: (1) Win immediately if possible, (2) Block opponent if they can win, (3) 50/50 random choice between win/block when both apply, (4) Random valid move otherwise
- Added `mostlyRandomStrategy` to `src/models/Strategies.ts` with `findWinningMoves` helper
- Added "Mostly random" radio button in the difficulty selector UI
- Updated `strategyLabel` in `PastGame.ts` to display "Mostly random"
- Comprehensive tests covering all priority scenarios, conflict resolution, edge cases, and random distribution