### PR TITLE
Replace unicode emojis with Heroicons for a more polished look

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app-template",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "clsx": "^2.1.1",
         "ramda": "^0.30.0",
         "react": "^18.2.0",
@@ -961,6 +962,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "*.{ts,tsx,js,jsx,css,md,json}": "prettier --write"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "clsx": "^2.1.1",
     "ramda": "^0.30.0",
     "react": "^18.2.0",

--- a/src/components/ConfirmationDialog.test.tsx
+++ b/src/components/ConfirmationDialog.test.tsx
@@ -1,6 +1,7 @@
 import {render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ConfirmationDialog from './ConfirmationDialog'
+import {TrashIcon} from '@heroicons/react/24/solid'
 
 describe('ConfirmationDialog', () => {
   it('does not render when open is false', () => {
@@ -30,7 +31,7 @@ describe('ConfirmationDialog', () => {
   })
 
   it('renders with default icon, labels, and dataTestId', () => {
-    render(
+    const {container} = render(
       <ConfirmationDialog
         open={true}
         onClose={() => {}}
@@ -39,13 +40,13 @@ describe('ConfirmationDialog', () => {
       />,
     )
 
-    expect(screen.getByText('⚠️')).toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Confirm'})).toBeInTheDocument()
   })
 
   it('renders custom labels and icon', () => {
-    render(
+    const {container} = render(
       <ConfirmationDialog
         open={true}
         onClose={() => {}}
@@ -53,11 +54,11 @@ describe('ConfirmationDialog', () => {
         message="Delete everything?"
         confirmLabel="Delete"
         cancelLabel="Go Back"
-        icon="🗑️"
+        icon={<TrashIcon className="h-16 w-16 text-honey" />}
       />,
     )
 
-    expect(screen.getByText('🗑️')).toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Go Back'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument()
   })

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -1,12 +1,14 @@
 import Dialog from './Dialog.tsx'
 import Button from './Button.tsx'
+import {ExclamationTriangleIcon} from '@heroicons/react/24/solid'
+import type {ReactNode} from 'react'
 
 interface ConfirmationDialogProps {
   open: boolean
   onClose: () => void
   onConfirm: () => void
   message: string
-  icon?: string
+  icon?: ReactNode
   confirmLabel?: string
   cancelLabel?: string
   accentClassName?: string
@@ -19,7 +21,7 @@ function ConfirmationDialog({
   onClose,
   onConfirm,
   message,
-  icon = '⚠️',
+  icon = <ExclamationTriangleIcon className="mx-auto h-16 w-16 text-wood/60" />,
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   accentClassName,
@@ -30,7 +32,7 @@ function ConfirmationDialog({
     <Dialog open={open} onClose={onClose} accentClassName={accentClassName}>
       {closeDialog => (
         <>
-          <div className="mb-3 text-5xl" aria-hidden="true">
+          <div className="mb-3" aria-hidden="true">
             {icon}
           </div>
           <p

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,5 +1,6 @@
 import Board from './Board.tsx'
 import clsx from 'clsx'
+import {StarIcon, HandThumbUpIcon} from '@heroicons/react/24/solid'
 import {useEffect, useMemo, useState} from 'react'
 import {
   BoardModel,
@@ -201,9 +202,13 @@ export function Game({
       >
         {closeDialog => (
           <>
-            <div className="mb-3 text-5xl" aria-hidden="true">
-              {isWinStatus(status) && '🏆'}
-              {isDrawStatus(status) && '🤝'}
+            <div className="mb-3" aria-hidden="true">
+              {isWinStatus(status) && (
+                <StarIcon className="mx-auto h-16 w-16 text-honey" />
+              )}
+              {isDrawStatus(status) && (
+                <HandThumbUpIcon className="mx-auto h-16 w-16 text-wood/60" />
+              )}
             </div>
             <p
               className="mb-6 text-xl font-bold text-bark"


### PR DESCRIPTION
## Summary

- Replace unicode emojis (🏆, 🤝) in game end dialogs with Heroicons (`StarIcon`, `HandThumbUpIcon`) from `@heroicons/react/24/solid`
- Win dialog uses `StarIcon` with `text-honey` color
- Draw dialog uses `HandThumbUpIcon` with `text-wood/60` color
- Icons remain purely decorative with `aria-hidden="true"`

Closes #66