### PR TITLE
Add game status area with elapsed time, AI thinking indicator, and strategy display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,6 +201,7 @@ function App() {
         {!!showGame && (
           <Game
             strategy={strategyMap[strategyName]}
+            strategyName={strategyName}
             onReturnToWelcome={() => setShowGame(false)}
             onGameComplete={handleGameComplete}
           />

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import {act, render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Game from './Game'
 import {Strategy} from '../models/Strategies.ts'
@@ -666,6 +666,145 @@ describe('Game', () => {
       expect(
         screen.getByRole('button', {name: 'Return to Welcome Page'}),
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('elapsed time', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('starts at 00:00', () => {
+      render(<Game />)
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('00:00')
+    })
+
+    it('increments every second during gameplay', () => {
+      render(<Game strategyName="deterministic" />)
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('00:00')
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('00:03')
+    })
+
+    it('stops incrementing when game has already ended', () => {
+      const boardModel = placeMoves(
+        [0, 'X'],
+        [4, 'O'],
+        [1, 'X'],
+        [6, 'O'],
+        [2, 'X'],
+      )
+
+      render(
+        <Game initialBoardModel={boardModel} strategyName="deterministic" />,
+      )
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('00:00')
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('00:00')
+    })
+
+    it('formats time correctly for minutes and seconds', () => {
+      render(<Game strategyName="deterministic" />)
+
+      act(() => {
+        vi.advanceTimersByTime(125_000)
+      })
+
+      expect(screen.getByTestId('elapsed-time')).toHaveTextContent('02:05')
+    })
+  })
+
+  describe('AI thinking indicator', () => {
+    it('does not show when AI is not thinking', () => {
+      render(<Game />)
+
+      expect(screen.queryByTestId('ai-thinking')).not.toBeInTheDocument()
+    })
+
+    it('shows when AI is thinking after player makes a move', async () => {
+      const user = userEvent.setup()
+      const strategy: Strategy = vi.fn().mockReturnValue(8).mockName('strategy')
+
+      render(<Game strategy={strategy} />)
+
+      const cells = screen.getAllByTestId('cell')
+      await user.click(cells[0])
+
+      expect(screen.getByTestId('ai-thinking')).toBeInTheDocument()
+
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId('ai-thinking')).not.toBeInTheDocument()
+        },
+        {timeout: 3000},
+      )
+    })
+
+    it('does not show when game ends on player move', async () => {
+      const user = userEvent.setup()
+      const boardModel = placeMoves([0, 'X'], [4, 'O'], [1, 'X'], [6, 'O'])
+      const strategy: Strategy = vi.fn().mockName('strategy')
+
+      render(<Game initialBoardModel={boardModel} strategy={strategy} />)
+
+      await user.click(screen.getAllByTestId('cell')[2])
+
+      expect(screen.queryByTestId('ai-thinking')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('strategy display', () => {
+    it('does not show when strategyName is not provided', () => {
+      render(<Game />)
+
+      expect(screen.queryByTestId('strategy-display')).not.toBeInTheDocument()
+    })
+
+    it('shows deterministic strategy', () => {
+      render(<Game strategyName="deterministic" />)
+
+      expect(screen.getByTestId('strategy-display')).toHaveTextContent(
+        'Playing against: Deterministic',
+      )
+    })
+
+    it('shows random strategy', () => {
+      render(<Game strategyName="random" />)
+
+      expect(screen.getByTestId('strategy-display')).toHaveTextContent(
+        'Playing against: Random',
+      )
+    })
+
+    it('shows mostlyRandom strategy', () => {
+      render(<Game strategyName="mostlyRandom" />)
+
+      expect(screen.getByTestId('strategy-display')).toHaveTextContent(
+        'Playing against: Mostly random',
+      )
+    })
+
+    it('shows minimax strategy', () => {
+      render(<Game strategyName="minimax" />)
+
+      expect(screen.getByTestId('strategy-display')).toHaveTextContent(
+        'Playing against: Minimax',
+      )
     })
   })
 })

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -9,8 +9,12 @@ import {
   placeMove,
   PieceOrEmpty,
 } from '../models/GameModel.ts'
-import {deterministicStrategy, Strategy} from '../models/Strategies.ts'
-import {PastGameResult} from '../models/PastGame.ts'
+import {
+  deterministicStrategy,
+  Strategy,
+  StrategyName,
+} from '../models/Strategies.ts'
+import {PastGameResult, strategyLabel} from '../models/PastGame.ts'
 import {
   gameStatus,
   getWinningFields,
@@ -21,6 +25,12 @@ import {
 import Button from './Button.tsx'
 import ConfirmationDialog from './ConfirmationDialog.tsx'
 import Dialog from './Dialog.tsx'
+
+function formatElapsedSeconds(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
 
 function useCypress(
   boardModel: PieceOrEmpty[],
@@ -51,6 +61,7 @@ function useCypress(
 
 type GameProps = {
   strategy?: Strategy
+  strategyName?: StrategyName
   initialBoardModel?: BoardModel
   onReturnToWelcome?: () => void
   onGameComplete?: (boardModel: BoardModel, result: PastGameResult) => void
@@ -58,6 +69,7 @@ type GameProps = {
 
 export function Game({
   strategy = deterministicStrategy,
+  strategyName,
   initialBoardModel = createInitialBoardModel(),
   onReturnToWelcome,
   onGameComplete,
@@ -69,6 +81,7 @@ export function Game({
   const [showNotAllowedCursor, setShowNotAllowedCursor] = useState(false)
   const [lastMoveField, setLastMoveField] = useState<Field | null>(null)
   const [showAbortDialog, setShowAbortDialog] = useState(false)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
 
   useCypress(boardModel, setBoardModel)
 
@@ -84,6 +97,16 @@ export function Game({
   }, [isAIThinking])
 
   const status = useMemo(() => gameStatus(boardModel), [boardModel])
+
+  useEffect(() => {
+    if (!isTurnStatus(status)) return
+
+    const timer = setInterval(() => {
+      setElapsedSeconds(prev => prev + 1)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [status])
 
   const handleMove = () => {
     let handleMoveCalled = false
@@ -156,6 +179,44 @@ export function Game({
           <h1 className="py-4 text-center text-2xl font-bold text-bark sm:py-6 sm:text-3xl">
             {winMessage ?? 'Have fun with this game!'}
           </h1>
+          <div className="flex items-center gap-4 pb-2 text-sm text-bark/60">
+            {strategyName && (
+              <span data-testid="strategy-display">
+                Playing against: {strategyLabel(strategyName)}
+              </span>
+            )}
+            {strategyName && <span aria-hidden="true">·</span>}
+            <span data-testid="elapsed-time" className="font-mono tabular-nums">
+              {formatElapsedSeconds(elapsedSeconds)}
+            </span>
+            {isAIThinking && (
+              <span
+                data-testid="ai-thinking"
+                className="flex items-center"
+                aria-label="AI is thinking"
+              >
+                <span className="mr-0.5 text-bark/80">Thinking</span>
+                <span
+                  className="inline-block animate-thinking-dot"
+                  style={{animationDelay: '0ms'}}
+                >
+                  .
+                </span>
+                <span
+                  className="inline-block animate-thinking-dot"
+                  style={{animationDelay: '200ms'}}
+                >
+                  .
+                </span>
+                <span
+                  className="inline-block animate-thinking-dot"
+                  style={{animationDelay: '400ms'}}
+                >
+                  .
+                </span>
+              </span>
+            )}
+          </div>
           {onReturnToWelcome && (
             <div className="pb-2">
               <Button

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,10 @@ export default {
           from: {opacity: '0.5'},
           to: {opacity: '0'},
         },
+        'thinking-dot': {
+          '0%, 100%': {opacity: '0.3'},
+          '50%': {opacity: '1'},
+        },
       },
       animation: {
         'win-pop': 'win-pop 0.6s ease-out',
@@ -55,6 +59,7 @@ export default {
         'dialog-fade-out': 'dialog-fade-out 500ms ease-in-out forwards',
         'backdrop-fade-in': 'backdrop-fade-in 500ms ease-in-out forwards',
         'backdrop-fade-out': 'backdrop-fade-out 500ms ease-in-out forwards',
+        'thinking-dot': 'thinking-dot 1.2s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary

- **Elapsed time stopwatch**: Displays time elapsed since game start in MM:SS format. Starts when the game begins, stops when the game ends (win/draw).
- **AI thinking indicator**: Shows a "Thinking..." animation with pulsing dots during the 1-second AI move delay, providing visual feedback that the AI is processing.
- **Strategy display**: Shows the current AI strategy name (e.g., "Playing against: Minimax") throughout the game using the existing `strategyLabel()` function.

## Changes

- `src/components/Game.tsx`: Added `strategyName` prop, `elapsedSeconds` state with timer effect, `formatElapsedSeconds` helper, and status area UI between heading and button
- `src/App.tsx`: Pass `strategyName` prop to `Game` component
- `tailwind.config.js`: Added `thinking-dot` keyframe animation and animation utility
- `src/components/Game.test.tsx`: Added tests for elapsed time (start, increment, stop, format), AI thinking indicator (visibility, disappearance), and strategy display (all 4 strategies + no prop)

## Test plan

- [x] All 274 tests pass (including 12 new tests)
- [x] Lint passes with zero warnings
- [x] TypeScript build succeeds
- [x] Prettier formatting applied

Closes #73