### PR TITLE
Improve Past Games display with hover interactions and winning highlights

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -210,4 +210,81 @@ describe('App', () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  describe('Past Games hover highlights', () => {
+    const xWinBoardModel = ['X', 'X', 'X', 'O', 'O', '', '', '', ''] as const
+
+    const drawBoardModel = [
+      'X',
+      'O',
+      'X',
+      'X',
+      'X',
+      'O',
+      'O',
+      'X',
+      'O',
+    ] as const
+
+    it('highlights winning cells when hovering over a past game where X won', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem(
+        'pastGames',
+        JSON.stringify([
+          {
+            id: 'game-x-win',
+            boardModel: xWinBoardModel,
+            result: 'X',
+            strategy: 'deterministic',
+            timestamp: Date.now(),
+          },
+        ]),
+      )
+      render(<App />)
+
+      const cards = screen.getAllByTestId('past-game-card')
+      const cells = cards[0].querySelectorAll('[data-testid="cell"]')
+
+      expect(cells[0]).not.toHaveClass('bg-flame')
+      expect(cells[1]).not.toHaveClass('bg-flame')
+      expect(cells[2]).not.toHaveClass('bg-flame')
+
+      await user.hover(cards[0])
+
+      expect(cells[0]).toHaveClass('bg-flame')
+      expect(cells[1]).toHaveClass('bg-flame')
+      expect(cells[2]).toHaveClass('bg-flame')
+      expect(cells[3]).not.toHaveClass('bg-flame')
+
+      await user.unhover(cards[0])
+
+      expect(cells[0]).not.toHaveClass('bg-flame')
+    })
+
+    it('does not highlight any cells when hovering over a draw game', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem(
+        'pastGames',
+        JSON.stringify([
+          {
+            id: 'game-draw',
+            boardModel: drawBoardModel,
+            result: 'draw',
+            strategy: 'deterministic',
+            timestamp: Date.now(),
+          },
+        ]),
+      )
+      render(<App />)
+
+      const cards = screen.getAllByTestId('past-game-card')
+      const cells = cards[0].querySelectorAll('[data-testid="cell"]')
+
+      await user.hover(cards[0])
+
+      cells.forEach(cell => {
+        expect(cell).not.toHaveClass('bg-flame')
+      })
+    })
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
 import {BoardModel} from './models/GameModel.ts'
 import {PastGameResult} from './models/PastGame.ts'
 import {useLocalStorage} from './hooks/useLocalStorage.ts'
+import {getWinningFields} from './models/GameStatus.ts'
 
 type ShowGameStatus = false | 0 | true
 
@@ -33,6 +34,7 @@ function WelcomePage({
   onClearHistory: () => void
 }) {
   const [showClearHistoryDialog, setShowClearHistoryDialog] = useState(false)
+  const [hoveredGameId, setHoveredGameId] = useState<string | null>(null)
 
   return (
     <>
@@ -125,8 +127,18 @@ function WelcomePage({
                 key={game.id}
                 className="flex-col rounded-xl border-2 border-wood/30 bg-cream/50 p-2 shadow-md hover:border-wood/50"
                 data-testid="past-game-card"
+                onMouseEnter={() => setHoveredGameId(game.id)}
+                onMouseLeave={() => setHoveredGameId(null)}
               >
-                <Board interactive={false} boardModel={game.boardModel} />
+                <Board
+                  interactive={false}
+                  boardModel={game.boardModel}
+                  winningFields={
+                    hoveredGameId === game.id
+                      ? getWinningFields(game.boardModel)
+                      : null
+                  }
+                />
                 <div className="mt-1 text-center text-sm font-semibold text-bark">
                   {resultLabel(game.result)}
                 </div>

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -138,6 +138,43 @@ describe('Cell', () => {
 
       expect(handleClick).not.toHaveBeenCalled()
     })
+
+    it('does not show cursor-not-allowed on empty cell', () => {
+      render(<Cell interactive={false} />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+    })
+
+    it('does not show cursor-not-allowed on X piece', () => {
+      render(<Cell interactive={false} piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+    })
+
+    it('does not show cursor-not-allowed on O piece', () => {
+      render(<Cell interactive={false} piece="O" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('cursor-not-allowed')
+    })
+
+    it('has transition-colors for smooth hover transitions', () => {
+      render(<Cell interactive={false} piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).toHaveClass('transition-colors')
+    })
+
+    it('applies highlight styling without pop animation when highlighted', () => {
+      render(<Cell interactive={false} piece="X" highlighted />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).toHaveClass('bg-flame')
+      expect(cell).toHaveClass('text-cream')
+      expect(cell).not.toHaveClass('animate-win-pop')
+    })
   })
 
   describe('cursor delay on X piece', () => {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -7,6 +7,8 @@ function classes(
   isFlashing: boolean,
   cursorDelayed: boolean,
 ) {
+  const isNonInteractive = interactive === false
+
   return clsx(
     'flex items-center justify-center',
     'text-5xl font-bold text-bark',
@@ -20,27 +22,35 @@ function classes(
       'border-b-0': noBorder.includes('b'),
       'border-l-0': noBorder.includes('l'),
     },
-    {'transition-colors duration-1000': piece === 'X' && !highlighted},
+    {'transition-colors duration-300': isNonInteractive},
+    {
+      'transition-colors duration-1000':
+        piece === 'X' && !highlighted && !isNonInteractive,
+    },
     {
       'bg-honey/30': isFlashing && piece === 'O' && !highlighted,
     },
     {
       'transition-colors duration-1000':
-        piece === 'O' && !isFlashing && !highlighted,
+        piece === 'O' && !isFlashing && !highlighted && !isNonInteractive,
     },
     {
       'cursor-pointer hover:bg-honey/30':
-        interactive !== false &&
+        !isNonInteractive &&
         (!piece || (piece === 'X' && (isFlashing || cursorDelayed))),
     },
     {
       'cursor-not-allowed':
-        (piece && (piece === 'O' || (!cursorDelayed && !isFlashing))) ||
-        (!piece && interactive === false),
+        !isNonInteractive &&
+        piece &&
+        (piece === 'O' || (!cursorDelayed && !isFlashing)),
     },
     {
       'animate-win-pop bg-flame text-cream transition-colors duration-500':
-        highlighted,
+        highlighted && !isNonInteractive,
+    },
+    {
+      'bg-flame text-cream': highlighted && isNonInteractive,
     },
   )
 }


### PR DESCRIPTION
## Summary

- Remove `cursor-not-allowed` from non-interactive (past game) board cells — past games are display-only, so they now show a default cursor instead of a forbidden icon
- Add hover-to-reveal winning highlights on past game boards — hovering over a past game card shows the winning cells with a smooth fade-in/fade-out color transition (using `getWinningFields`)
- Draw games show no highlight on hover (no winner)
- Non-interactive cells use `transition-colors duration-300` for smooth hover transitions, and highlighted cells use `bg-flame text-cream` without the `animate-win-pop` animation for a subtle hover effect
- Added 7 new tests covering cursor behavior, hover highlighting, and draw handling

## Files Changed

- `src/components/Cell.tsx` — Refactored `classes()` to use `isNonInteractive` flag; removed `cursor-not-allowed` for non-interactive cells; added `transition-colors duration-300` and separate highlight class (`bg-flame text-cream` without `animate-win-pop`) for non-interactive cells
- `src/App.tsx` — Added `hoveredGameId` state; imports `getWinningFields`; passes `winningFields` prop to `Board` when a past game card is hovered
- `src/components/Cell.test.tsx` — Added tests for no `cursor-not-allowed`, `transition-colors`, and highlight styling on non-interactive cells
- `src/App.test.tsx` — Added tests for hover-to-highlight on X-win games and no-highlight on draw games

Closes #78