### PR TITLE
Refine primary button design to be more subtle while maintaining prominence

### DIFF
--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -61,7 +61,8 @@ describe('Button', () => {
     render(<Button>Click me</Button>)
 
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('bg-flame')
+    expect(button).toHaveClass('bg-flame/90')
+    expect(button).toHaveClass('border-flame/30')
     expect(button).toHaveClass('text-white')
   })
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -13,12 +13,14 @@ const classes = (size: ButtonSize, variant: ButtonVariant = 'primary') => {
       return clsx(
         'border-2 border-flame bg-cream font-semibold text-flame',
         'hover:bg-flame/10',
+        'transition-all duration-200',
         focusStyles,
       )
     }
     return clsx(
-      'bg-flame font-semibold text-white',
-      'hover:bg-flame-dark',
+      'border border-flame/30 bg-flame/90 font-semibold text-white',
+      'hover:border-flame/50 hover:bg-flame',
+      'transition-all duration-200',
       focusStyles,
     )
   }


### PR DESCRIPTION
## Summary

- Softens the primary button's background from solid `bg-flame` to `bg-flame/90` (90% opacity) to reduce visual harshness
- Adds a subtle `border border-flame/30` to the primary button for visual refinement and consistency with the secondary button's border treatment
- Replaces the jarring `hover:bg-flame-dark` hover state with a smoother `hover:bg-flame` (transitioning from 90% → 100% opacity), plus a subtle `hover:border-flame/50` effect
- Adds `transition-all duration-200` to both primary and secondary variants for smooth hover/focus transitions

Closes #81