### PR TITLE
Fix Past Games layout - responsive grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,7 @@ function WelcomePage({
       ) : (
         <>
           <div
-            className="flex flex-wrap justify-around gap-6"
+            className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4"
             data-testid="past-games-list"
           >
             {pastGames.map(game => (


### PR DESCRIPTION
## Summary
- Replace `flex flex-wrap justify-around` with responsive CSS Grid layout (`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6`)
- Fixes cramped rows (11 games in one row) and uneven spacing in partial rows
- Ensures consistent alignment: 2 cols mobile, 3 cols tablet, 4 cols desktop

Closes #83