### PR TITLE
Fix: Move highlight incorrectly appears briefly in Past Games display

### DIFF
--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -175,6 +175,38 @@ describe('Cell', () => {
       expect(cell).toHaveClass('text-cream')
       expect(cell).not.toHaveClass('animate-win-pop')
     })
+
+    it('does not show move highlight flash on O piece immediately after mount', () => {
+      vi.useFakeTimers()
+      render(<Cell interactive={false} piece="O" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('bg-honey/30')
+
+      vi.useRealTimers()
+    })
+
+    it('does not show move highlight flash on O piece after piece update', () => {
+      vi.useFakeTimers()
+      const {rerender} = render(<Cell interactive={false} />)
+      rerender(<Cell interactive={false} piece="O" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('bg-honey/30')
+
+      vi.useRealTimers()
+    })
+
+    it('does not show cursor-pointer on X piece', () => {
+      vi.useFakeTimers()
+      render(<Cell interactive={false} piece="X" />)
+      const cell = screen.getByTestId('cell')
+
+      expect(cell).not.toHaveClass('cursor-pointer')
+      expect(cell).not.toHaveClass('hover:bg-honey/30')
+
+      vi.useRealTimers()
+    })
   })
 
   describe('cursor delay on X piece', () => {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -28,7 +28,8 @@ function classes(
         piece === 'X' && !highlighted && !isNonInteractive,
     },
     {
-      'bg-honey/30': isFlashing && piece === 'O' && !highlighted,
+      'bg-honey/30':
+        isFlashing && piece === 'O' && !highlighted && !isNonInteractive,
     },
     {
       'transition-colors duration-1000':
@@ -55,10 +56,11 @@ function classes(
   )
 }
 
-function useFlashing(piece?: PieceOrEmpty): boolean {
+function useFlashing(piece?: PieceOrEmpty, interactive?: boolean): boolean {
   const [stopFlashing, setStopFlashing] = useState(false)
 
   useEffect(() => {
+    if (!interactive) return
     if (piece) {
       const timer = setTimeout(() => {
         setStopFlashing(true)
@@ -68,24 +70,25 @@ function useFlashing(piece?: PieceOrEmpty): boolean {
         clearTimeout(timer)
       }
     }
-  }, [piece])
+  }, [piece, interactive])
 
-  return !!piece && !stopFlashing
+  return interactive ? !!piece && !stopFlashing : false
 }
 
-function useCursorDelay(piece?: PieceOrEmpty): boolean {
+function useCursorDelay(piece?: PieceOrEmpty, interactive?: boolean): boolean {
   const [cursorDelayed, setCursorDelayed] = useState(false)
 
   useEffect(() => {
+    if (!interactive) return
     if (piece === 'X') {
       setCursorDelayed(true)
       const timer = setTimeout(() => setCursorDelayed(false), 1000)
       return () => clearTimeout(timer)
     }
     setCursorDelayed(false)
-  }, [piece])
+  }, [piece, interactive])
 
-  return cursorDelayed
+  return interactive ? cursorDelayed : false
 }
 
 export type BorderPosition = 't' | 'b' | 'l' | 'r'
@@ -102,8 +105,8 @@ type CellProps = {
 function Cell(props: CellProps) {
   const {piece, onClick, interactive = true} = props
 
-  const isFlashing = useFlashing(piece)
-  const cursorDelayed = useCursorDelay(piece)
+  const isFlashing = useFlashing(piece, interactive)
+  const cursorDelayed = useCursorDelay(piece, interactive)
 
   const style =
     props.highlighted && props.highlightDelay !== undefined


### PR DESCRIPTION
## Summary

Fixes #85 — When returning to the welcome page after completing a game, the cell hover highlight (used during gameplay to show where a move will be placed) briefly appeared in the Past Games display boards.

## Root Cause

The `useFlashing` and `useCursorDelay` hooks in `Cell.tsx` activated on every mount regardless of the `interactive` prop. When past game cards rendered fresh, O cells flashed `bg-honey/30` for 800ms because `isFlashing` returned `true` on initial render. The `bg-honey/30` condition also lacked a `!isNonInteractive` guard.

## Changes

- **`useFlashing` and `useCursorDelay`**: Added `interactive` parameter; hooks now short-circuit (return `false`, skip effects) when `interactive === false`
- **`classes()` function**: Added `&& !isNonInteractive` guard to the `bg-honey/30` condition for defense in depth
- **`Cell` component**: Passes `interactive` prop to both hooks
- **Tests**: Added 3 new test cases verifying non-interactive cells don't show move highlight flash or cursor styles

## Acceptance Criteria

- ✅ No cell highlight appears in past games display on page load
- ✅ No brief flashing/flickering of highlight effects
- ✅ Past games show winning field highlights on hover (unchanged)
- ✅ Active game board still shows move-placement highlight normally
- ✅ No console errors during state transitions
- ✅ All 284 tests pass, lint clean, build succeeds