### PR TITLE
Add relative time display to Past Games cards with auto-refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.20",
         "ramda": "^0.30.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -3435,10 +3436,10 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==",
-      "dev": true
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.20",
     "ramda": "^0.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,19 @@ import Button from './components/Button.tsx'
 import ConfirmationDialog from './components/ConfirmationDialog.tsx'
 import Game from './components/Game.tsx'
 import clsx from 'clsx'
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 import Board from './components/Board.tsx'
 import {strategyMap, StrategyName} from './models/Strategies.ts'
 import {
   PastGame,
+  PastGameResult,
   createPastGame,
+  formatAbsoluteTime,
+  formatRelativeTime,
   resultLabel,
   strategyLabel,
 } from './models/PastGame.ts'
 import {BoardModel} from './models/GameModel.ts'
-import {PastGameResult} from './models/PastGame.ts'
 import {useLocalStorage} from './hooks/useLocalStorage.ts'
 import {getWinningFields} from './models/GameStatus.ts'
 
@@ -35,6 +37,21 @@ function WelcomePage({
 }) {
   const [showClearHistoryDialog, setShowClearHistoryDialog] = useState(false)
   const [hoveredGameId, setHoveredGameId] = useState<string | null>(null)
+  const [currentTime, setCurrentTime] = useState(Date.now())
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(Date.now())
+    }, 60000)
+
+    const handleFocus = () => setCurrentTime(Date.now())
+    window.addEventListener('focus', handleFocus)
+
+    return () => {
+      clearInterval(interval)
+      window.removeEventListener('focus', handleFocus)
+    }
+  }, [])
 
   return (
     <>
@@ -144,6 +161,12 @@ function WelcomePage({
                 </div>
                 <div className="text-center text-xs text-bark/60">
                   {strategyLabel(game.strategy)}
+                </div>
+                <div
+                  className="text-center text-xs text-bark/50"
+                  title={formatAbsoluteTime(game.timestamp)}
+                >
+                  {formatRelativeTime(game.timestamp, currentTime)}
                 </div>
               </div>
             ))}

--- a/src/models/PastGame.test.ts
+++ b/src/models/PastGame.test.ts
@@ -1,4 +1,10 @@
-import {createPastGame, resultLabel, strategyLabel} from './PastGame.ts'
+import {
+  createPastGame,
+  formatAbsoluteTime,
+  formatRelativeTime,
+  resultLabel,
+  strategyLabel,
+} from './PastGame.ts'
 import {placeMoves} from './GameModel.ts'
 import {describe} from 'vitest'
 
@@ -98,6 +104,78 @@ describe('PastGame', () => {
 
     it('labels mostlyRandom as Mostly random', () => {
       expect(strategyLabel('mostlyRandom')).toEqual('Mostly random')
+    })
+  })
+
+  describe('formatRelativeTime', () => {
+    const now = 1700000000000
+
+    it('returns "just now" for less than 45 seconds ago', () => {
+      expect(formatRelativeTime(now - 30000, now)).toEqual('just now')
+      expect(formatRelativeTime(now - 44000, now)).toEqual('just now')
+      expect(formatRelativeTime(now, now)).toEqual('just now')
+    })
+
+    it('returns "1m ago" for 45-89 seconds ago', () => {
+      expect(formatRelativeTime(now - 45000, now)).toEqual('1m ago')
+      expect(formatRelativeTime(now - 89000, now)).toEqual('1m ago')
+    })
+
+    it('returns minutes ago for 90 seconds to ~44 minutes', () => {
+      expect(formatRelativeTime(now - 90000, now)).toEqual('2m ago')
+      expect(formatRelativeTime(now - 300000, now)).toEqual('5m ago')
+      expect(formatRelativeTime(now - 2640000, now)).toEqual('44m ago')
+    })
+
+    it('returns "1h ago" for ~45-89 minutes ago', () => {
+      expect(formatRelativeTime(now - 3600000, now)).toEqual('1h ago')
+      expect(formatRelativeTime(now - 5340000, now)).toEqual('1h ago')
+    })
+
+    it('returns hours ago for 90 minutes to ~22 hours', () => {
+      expect(formatRelativeTime(now - 7200000, now)).toEqual('2h ago')
+      expect(formatRelativeTime(now - 36000000, now)).toEqual('10h ago')
+    })
+
+    it('returns "1d ago" for ~22-48 hours ago', () => {
+      expect(formatRelativeTime(now - 86400000, now)).toEqual('1d ago')
+    })
+
+    it('returns days ago for 2-56 days', () => {
+      expect(formatRelativeTime(now - 259200000, now)).toEqual('3d ago')
+    })
+
+    it('returns "1mo ago" for ~56-112 days ago', () => {
+      expect(formatRelativeTime(now - 5184000000, now)).toEqual('1mo ago')
+    })
+
+    it('returns months ago for over 112 days', () => {
+      expect(formatRelativeTime(now - 15552000000, now)).toEqual('6mo ago')
+    })
+
+    it('returns "1y ago" for over a year', () => {
+      expect(formatRelativeTime(now - 31536000000, now)).toEqual('1y ago')
+    })
+
+    it('uses Date.now() as default for now parameter', () => {
+      const result = formatRelativeTime(Date.now() - 10000)
+      expect(result).toEqual('just now')
+    })
+  })
+
+  describe('formatAbsoluteTime', () => {
+    it('formats a timestamp as human-readable date and time', () => {
+      const timestamp = new Date('2026-12-06T15:45:00').getTime()
+      const result = formatAbsoluteTime(timestamp)
+      expect(result).toContain('December')
+      expect(result).toContain('2026')
+      expect(result).toContain('6')
+    })
+
+    it('includes the time with AM/PM', () => {
+      const timestamp = new Date('2026-06-15T09:30:00').getTime()
+      const result = formatAbsoluteTime(timestamp)
+      expect(result).toMatch(/\d+:\d+ (AM|PM)/)
     })
   })
 })

--- a/src/models/PastGame.ts
+++ b/src/models/PastGame.ts
@@ -1,5 +1,9 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
 import {BoardModel, Piece} from './GameModel.ts'
 import {StrategyName} from './Strategies.ts'
+
+dayjs.extend(relativeTime)
 
 export type PastGameResult = Piece | 'draw'
 
@@ -38,4 +42,28 @@ export function strategyLabel(strategy: StrategyName): string {
     minimax: 'Minimax',
   }
   return labels[strategy]
+}
+
+export function formatRelativeTime(
+  timestamp: number,
+  now: number = Date.now(),
+): string {
+  const diffMs = now - timestamp
+  const diffSeconds = Math.floor(diffMs / 1000)
+
+  if (diffSeconds < 45) return 'just now'
+  if (diffSeconds < 90) return '1m ago'
+  if (diffSeconds < 2670) return `${Math.round(diffSeconds / 60)}m ago`
+  if (diffSeconds < 5340) return '1h ago'
+  if (diffSeconds < 80640) return `${Math.round(diffSeconds / 3600)}h ago`
+  if (diffSeconds < 161280) return '1d ago'
+  if (diffSeconds < 4838400) return `${Math.round(diffSeconds / 86400)}d ago`
+  if (diffSeconds < 9676800) return '1mo ago'
+  if (diffSeconds < 31536000)
+    return `${Math.round(diffSeconds / 2592000)}mo ago`
+  return '1y ago'
+}
+
+export function formatAbsoluteTime(timestamp: number): string {
+  return dayjs(timestamp).format('MMMM D, YYYY [at] h:mm A')
 }


### PR DESCRIPTION
## Summary

- Add abbreviated relative time display (e.g. "5m ago", "3d ago") below result and strategy on each Past Games card
- Auto-refresh every 60 seconds and immediately on tab focus regain
- Show exact date/time in tooltip on hover (`title` attribute) for accessibility
- Add `formatRelativeTime` and `formatAbsoluteTime` utility functions to `PastGame.ts` model (business logic separated from UI)
- Install dayjs for absolute time formatting
- Add unit tests for both new functions

## Changes

- **`src/models/PastGame.ts`**: Added `formatRelativeTime(timestamp, now?)` and `formatAbsoluteTime(timestamp)` functions
- **`src/App.tsx`**: Added `currentTime` state with `useEffect` for 60s interval + focus listener; rendered relative time with tooltip on past game cards
- **`src/models/PastGame.test.ts`**: Tests for all relative time thresholds and absolute time formatting
- **`package.json`**: Added `dayjs` dependency

Closes #91