### PR TITLE
Fix piece sizing proportions in Past Games boards

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -9,7 +9,7 @@ import {
 } from '../models/GameModel.ts'
 
 const classes = clsx(
-  'wood-grain grid aspect-square max-h-full grid-cols-3 grid-rows-3 overflow-hidden rounded-lg shadow-lg',
+  'wood-grain board-container grid aspect-square max-h-full grid-cols-3 grid-rows-3 overflow-hidden rounded-lg shadow-lg',
 )
 
 const fieldsNoBorder: BorderPosition[][] = [

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -11,7 +11,7 @@ function classes(
 
   return clsx(
     'flex items-center justify-center',
-    'text-5xl font-bold text-bark',
+    'piece-text font-bold text-bark',
     'border border-wood-dark',
     'select-none bg-cream/50',
     'min-h-[44px] min-w-[44px] sm:min-h-0 sm:min-w-0',

--- a/src/main.css
+++ b/src/main.css
@@ -23,3 +23,12 @@
 .piece-shadow {
   text-shadow: 1px 2px 3px rgba(0, 0, 0, 0.25);
 }
+
+.board-container {
+  container-type: inline-size;
+}
+
+.piece-text {
+  font-size: 15cqw;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary

- Replaced fixed `text-5xl` (3rem/48px) font size on Cell pieces with proportional `15cqw` container query units so pieces scale correctly relative to their board size
- Added `board-container` class with `container-type: inline-size` to the Board grid, enabling `cqw` units in child cells
- Added `piece-text` class in `main.css` with `font-size: 15cqw; line-height: 1` (matching the original `text-5xl` line-height)

## Problem

Pieces (X and O) in Past Games board cards appeared disproportionately large compared to the main playing board. The fixed `text-5xl` font size didn't scale down when the board was rendered at smaller sizes, making pieces fill almost the entire cell in compact views.

## Fix

Uses CSS container queries (`cqw` units) to make piece font size proportional to the board width:
- At 320px (main board sm): `15cqw` = 48px (identical to previous `text-5xl`)
- At smaller sizes: automatically scales proportionally
- Same proportional sizing logic applies everywhere (main board and past games)

Closes #89