### PR TITLE
Use select menu for AI Strategy on mobile instead of radio buttons

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -85,7 +85,15 @@ describe('App', () => {
     expect(randomRadio).not.toBeChecked()
   })
 
-  it('allows switching to random strategy', async () => {
+  it('shows a select menu for mobile strategy selection', () => {
+    render(<App />)
+
+    const select = screen.getByTestId('strategy-select')
+    expect(select).toBeInTheDocument()
+    expect(select).toHaveValue('mostlyRandom')
+  })
+
+  it('allows switching to random strategy via radio', async () => {
     const user = userEvent.setup()
     render(<App />)
 
@@ -96,7 +104,7 @@ describe('App', () => {
     expect(screen.getByTestId('strategy-mostly-random')).not.toBeChecked()
   })
 
-  it('allows switching to deterministic strategy', async () => {
+  it('allows switching to deterministic strategy via radio', async () => {
     const user = userEvent.setup()
     render(<App />)
 
@@ -106,7 +114,7 @@ describe('App', () => {
     expect(screen.getByTestId('strategy-mostly-random')).not.toBeChecked()
   })
 
-  it('allows switching back to mostly random strategy', async () => {
+  it('allows switching back to mostly random strategy via radio', async () => {
     const user = userEvent.setup()
     render(<App />)
 
@@ -117,6 +125,16 @@ describe('App', () => {
     expect(screen.getByTestId('strategy-mostly-random')).toBeChecked()
     expect(screen.getByTestId('strategy-random')).not.toBeChecked()
     expect(screen.getByTestId('strategy-deterministic')).not.toBeChecked()
+  })
+
+  it('allows switching strategy via select menu', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.selectOptions(screen.getByTestId('strategy-select'), 'random')
+
+    expect(screen.getByTestId('strategy-select')).toHaveValue('random')
+    expect(screen.getByTestId('strategy-random')).toBeChecked()
   })
 
   it('does not show Clear History button when no games have been played', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,54 +60,67 @@ function WelcomePage({
       </h1>
       <div className="my-4 flex items-center justify-center gap-6">
         <span className="text-lg text-bark">AI Strategy:</span>
-        <label className="flex items-center gap-2">
-          <input
-            type="radio"
-            name="strategy"
-            value="deterministic"
-            checked={strategyName === 'deterministic'}
-            onChange={() => setStrategyName('deterministic')}
-            data-testid="strategy-deterministic"
-            className="accent-flame"
-          />
-          <span className="text-bark">Deterministic</span>
-        </label>
-        <label className="flex items-center gap-2">
-          <input
-            type="radio"
-            name="strategy"
-            value="random"
-            checked={strategyName === 'random'}
-            onChange={() => setStrategyName('random')}
-            data-testid="strategy-random"
-            className="accent-flame"
-          />
-          <span className="text-bark">Random</span>
-        </label>
-        <label className="flex items-center gap-2">
-          <input
-            type="radio"
-            name="strategy"
-            value="mostlyRandom"
-            checked={strategyName === 'mostlyRandom'}
-            onChange={() => setStrategyName('mostlyRandom')}
-            data-testid="strategy-mostly-random"
-            className="accent-flame"
-          />
-          <span className="text-bark">Mostly random</span>
-        </label>
-        <label className="flex items-center gap-2">
-          <input
-            type="radio"
-            name="strategy"
-            value="minimax"
-            checked={strategyName === 'minimax'}
-            onChange={() => setStrategyName('minimax')}
-            data-testid="strategy-minimax"
-            className="accent-flame"
-          />
-          <span className="text-bark">Minimax</span>
-        </label>
+        <div className="hidden gap-4 sm:flex">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="strategy"
+              value="deterministic"
+              checked={strategyName === 'deterministic'}
+              onChange={() => setStrategyName('deterministic')}
+              data-testid="strategy-deterministic"
+              className="accent-flame"
+            />
+            <span className="text-bark">Deterministic</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="strategy"
+              value="random"
+              checked={strategyName === 'random'}
+              onChange={() => setStrategyName('random')}
+              data-testid="strategy-random"
+              className="accent-flame"
+            />
+            <span className="text-bark">Random</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="strategy"
+              value="mostlyRandom"
+              checked={strategyName === 'mostlyRandom'}
+              onChange={() => setStrategyName('mostlyRandom')}
+              data-testid="strategy-mostly-random"
+              className="accent-flame"
+            />
+            <span className="text-bark">Mostly random</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="strategy"
+              value="minimax"
+              checked={strategyName === 'minimax'}
+              onChange={() => setStrategyName('minimax')}
+              data-testid="strategy-minimax"
+              className="accent-flame"
+            />
+            <span className="text-bark">Minimax</span>
+          </label>
+        </div>
+        <select
+          value={strategyName}
+          onChange={e => setStrategyName(e.target.value as StrategyName)}
+          data-testid="strategy-select"
+          className="rounded-md border-2 border-wood/30 bg-cream px-3 py-1.5 text-bark sm:hidden"
+        >
+          <option value="deterministic">Deterministic</option>
+          <option value="random">Random</option>
+          <option value="mostlyRandom">Mostly random</option>
+          <option value="minimax">Minimax</option>
+        </select>
       </div>
       <div
         className={clsx('my-3 flex justify-center', {


### PR DESCRIPTION
## Summary

- Show radio buttons for AI Strategy selection on desktop (≥640px / `sm:` breakpoint)
- Show a `<select>` dropdown menu for AI Strategy on mobile (<640px) where radio buttons are too wide
- Both controls share the same React state, so changing one updates the other
- Added tests for the select menu and renamed existing radio test descriptions for clarity

Closes #94