### PR TITLE
Stack confirmation dialog buttons vertically on mobile

### DIFF
--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -41,7 +41,7 @@ function ConfirmationDialog({
           >
             {message}
           </p>
-          <div className="flex gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             <Button
               variant="secondary"
               className="flex-1"


### PR DESCRIPTION
## Summary

- Closes #96
- On small screens, the two confirmation dialog buttons (Cancel/Confirm) overflow on a single row. This change stacks them vertically on mobile using `flex-col` and switches back to `flex-row` at the `sm` breakpoint.

## Changes

- Updated `ConfirmationDialog.tsx` button container from `flex gap-3` to `flex flex-col gap-3 sm:flex-row`

## Testing

- All 301 unit tests pass
- Lint and type-check pass
- Production build succeeds